### PR TITLE
Improve Readme, typos and add UTF-8 encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 <p align="center">
   See also:
   <a href="#related-repositories">AD-ML</a>,
-  <a href="#related-repositories">AD-DL</a>
+  <a href="#related-repositories">Clinica</a>
 </p>
 
 
@@ -22,8 +22,8 @@
 This repository contains a software framework for reproducible experiments with
 convolutional neural networks (CNN) on **automatic classification of Alzheimer's
 disease (AD) using anatomical MRI data** from the publicly available dataset
-ADNI. 
-The journal version of the paper describing the algorithmes here implemented
+ADNI.
+The journal version of the paper describing the algorithms here implemented
 can be found [here](https://doi.org/10.1016/j.media.2020.101694).
 
 Automatic Classification of AD using a classical machine learning approach can
@@ -42,7 +42,7 @@ All the papers described in the State of the art section of the manuscript may
 be found at this URL address: <https://www.zotero.org/groups/2337160/ad-dl>.
 
 
-## Main dependencies:
+## Main dependencies
 - Python >= 3.6
 - Clinica (needs only to perform preprocessing) >= 0.3.4
 - Numpy
@@ -80,9 +80,9 @@ pip install -e .
 
 `clinicadl` is an utility to be used with the command line.
 
-To have an overview of the general options proposed by the software type: 
+To have an overview of the general options proposed by the software type:
 
-```bash
+```text
 clinicadl -h
 
 usage: clinicadl [-h] [--verbose]
@@ -125,7 +125,7 @@ There are five kind of tasks that can be performed using the command line:
 
 - **Train neural networks.** Tensors obtained are used to perform the training of CNN models.
 
-- **MRI classification.** Previously trained models can be used to performe the inference of a particular or a set of MRI.
+- **MRI classification.** Previously trained models can be used to perform the inference of a particular or a set of MRI.
 
 For detailed instructions and options of each task type  `clinica 'task' -h`.
 
@@ -134,18 +134,21 @@ For detailed instructions and options of each task type  `clinica 'task' -h`.
 #### Preprocessing
 Typical use for `preprocessing`:
 
-```bash
-clinicadl preprocessing --np 32 \
-  $BIDS_DIR \
-  $CAPS_DIR \
-  $TSV_FILE \
-  $WORKING_DIR
+```text
+clinicadl preprocessing <bids_dir> <caps_dir> <working_dir> --np 32
 ```
+where:
+
+  - `bids_dir` is the input folder containing the dataset in a [BIDS](http://www.clinica.run/doc/BIDS/) hierarchy.
+  - `caps_dir` is the output folder containing the results in a [CAPS](http://www.clinica.run/doc/CAPS/Specifications/) hierarchy.
+  - `caps_dir` is the temporary directory to store pipelines intermediate results.
+  - `--np <N>` (optional) is the number of cores used to run in parallel (in the example, 32 cores are used).
+If you want to run the pipeline on a subset of your BIDS dataset, you can use the `-tsv` flag to specify in a TSV file the participants belonging to your subset.
 
 #### Tensor extraction
 
 These are the options available for the `extract` task:
-```
+```text
 usage: clinicadl extract [-h] [-psz PATCH_SIZE] [-ssz STRIDE_SIZE]
                          [-sd SLICE_DIRECTION] [-sm {original,rgb}]
                          [-np NPROC]
@@ -185,7 +188,7 @@ optional arguments:
 ### Unit testing
 
 Be sure to have the `pytest` library in order to run the test suite.  This test
-suite includes unit testing to be launched using the command line: 
+suite includes unit testing to be launched using the command line:
 ```
 pytest clinicadl/tests/
 ```
@@ -196,12 +199,12 @@ For sanity check trivial datasets can be generated to train or test/validate
 the predictive models.
 
 The follow command allow you to generate two kinds of synthetic datasets: fully
-separable (trivial) or intractable data (IRM with random noise added). 
-```
+separable (trivial) or intractable data (IRM with random noise added).
+```text
 python clinicadl generate {random,trivial} caps_directory tsv_path output_directory
 ```
 The intractable dataset will be made of noisy versions of the first image of
-the tsv file given at 
+the tsv file given at
 `tsv_path` associated to random labels.
 
 The trivial dataset includes two labels:
@@ -212,4 +215,3 @@ The trivial dataset includes two labels:
 
 - [Clinica: Software platform for clinical neuroimaging studies](https://github.com/aramis-lab/clinica)
 - [AD-ML: Framework for the reproducible classification of Alzheimer's disease using machine learning](https://github.com/aramis-lab/AD-ML)
-

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ usage: clinicadl extract [-h] [-psz PATCH_SIZE] [-ssz STRIDE_SIZE]
 
 positional arguments:
   caps_dir              Data using CAPS structure.
-  tsv_file              tsv file with sujets/sessions to process.
+  tsv_file              tsv file with subjects/sessions to process.
   working_dir           Working directory to save temporary file.
   {slice,patch,whole}   Method used to extract features. Three options:
                         'slice' to get 2D slices from the MRI, 'patch' to get

--- a/clinicadl/clinicadl/cli.py
+++ b/clinicadl/clinicadl/cli.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 import argparse
 
 from clinicadl.tools.deep_learning.iotools import Parameters
@@ -287,7 +289,7 @@ def parse_command_line():
             )
     generate_parser.add_argument(
             'tsv_path',
-            help='tsv path with sujets/sessions to use for data generation.',
+            help='TSV path with subjects/sessions to use for data generation.',
             default=None
             )
     generate_parser.add_argument(
@@ -366,7 +368,7 @@ def parse_command_line():
             )
     preprocessing_parser.add_argument(
             'tsv_file',
-            help='tsv file with sujets/sessions to process.',
+            help='TSV file with subjects/sessions to process.',
             default=None
             )
     preprocessing_parser.add_argument(
@@ -396,7 +398,7 @@ def parse_command_line():
             )
     extract_parser.add_argument(
             'tsv_file',
-            help='tsv file with sujets/sessions to process.',
+            help='TSV file with subjects/sessions to process.',
             default=None
             )
     extract_parser.add_argument(
@@ -462,7 +464,7 @@ def parse_command_line():
             default=None)
     train_parser.add_argument(
             'tsv_path',
-            help='tsv path with sujets/sessions to process.',
+            help='TSV path with subjects/sessions to process.',
             default=None)
     train_parser.add_argument(
             'output_dir',
@@ -658,7 +660,7 @@ def parse_command_line():
             default=None)
     classify_parser.add_argument(
             'tsv_path',
-            help='tsv path with sujets/sessions to process.',
+            help='TSV path with subjects/sessions to process.',
             default=None)
     classify_parser.add_argument(
             'output_dir',

--- a/clinicadl/clinicadl/main.py
+++ b/clinicadl/clinicadl/main.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 from . import cli
 from clinicadl.tools.deep_learning import commandline_to_json
 

--- a/clinicadl/clinicadl/patch_level/evaluation_multiCNN.py
+++ b/clinicadl/clinicadl/patch_level/evaluation_multiCNN.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 import argparse
 import os
 import torch

--- a/clinicadl/clinicadl/patch_level/evaluation_singleCNN.py
+++ b/clinicadl/clinicadl/patch_level/evaluation_singleCNN.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 import argparse
 import os
 import torchvision.transforms as transforms

--- a/clinicadl/clinicadl/patch_level/train_autoencoder.py
+++ b/clinicadl/clinicadl/patch_level/train_autoencoder.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 import argparse
 import copy
 import torch

--- a/clinicadl/clinicadl/patch_level/train_multiCNN.py
+++ b/clinicadl/clinicadl/patch_level/train_multiCNN.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 import argparse
 import copy
 import os

--- a/clinicadl/clinicadl/patch_level/train_singleCNN.py
+++ b/clinicadl/clinicadl/patch_level/train_singleCNN.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 import os
 import torch
 import argparse

--- a/clinicadl/clinicadl/patch_level/utils.py
+++ b/clinicadl/clinicadl/patch_level/utils.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 import torch
 import pandas as pd
 import numpy as np

--- a/clinicadl/clinicadl/preprocessing/T1_linear.py
+++ b/clinicadl/clinicadl/preprocessing/T1_linear.py
@@ -1,4 +1,4 @@
-
+# coding: utf8
 
 def preprocessing_t1w(bids_directory,
                       caps_directory,

--- a/clinicadl/clinicadl/preprocessing/T1_linear_utils.py
+++ b/clinicadl/clinicadl/preprocessing/T1_linear_utils.py
@@ -1,3 +1,4 @@
+# coding: utf8
 
 # Get containers to ptoduce the CAPS structure
 

--- a/clinicadl/clinicadl/preprocessing/T1_preparedl_utils.py
+++ b/clinicadl/clinicadl/preprocessing/T1_preparedl_utils.py
@@ -1,3 +1,4 @@
+# coding: utf8
 
 def extract_slices(preprocessed_T1, slice_direction=0, slice_mode='original'):
     """

--- a/clinicadl/clinicadl/preprocessing/model/resnet_qc.py
+++ b/clinicadl/clinicadl/preprocessing/model/resnet_qc.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 import torch
 import torch.nn as nn
 import math

--- a/clinicadl/clinicadl/preprocessing/model/squezenet_qc.py
+++ b/clinicadl/clinicadl/preprocessing/model/squezenet_qc.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 import torch
 import torch.nn as nn
 import math

--- a/clinicadl/clinicadl/preprocessing/model/util.py
+++ b/clinicadl/clinicadl/preprocessing/model/util.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 import torch
 import os
 

--- a/clinicadl/clinicadl/slice_level/evaluation_test.py
+++ b/clinicadl/clinicadl/slice_level/evaluation_test.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 import argparse
 import torchvision.transforms as transforms
 from torch.utils.data import DataLoader

--- a/clinicadl/clinicadl/slice_level/train_CNN.py
+++ b/clinicadl/clinicadl/slice_level/train_CNN.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 import argparse
 import torchvision.transforms as transforms
 from tensorboardX import SummaryWriter

--- a/clinicadl/clinicadl/slice_level/train_CNN_bad_data_split.py
+++ b/clinicadl/clinicadl/slice_level/train_CNN_bad_data_split.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 import argparse
 import torchvision.transforms as transforms
 from tensorboardX import SummaryWriter

--- a/clinicadl/clinicadl/slice_level/utils.py
+++ b/clinicadl/clinicadl/slice_level/utils.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 import torch
 from torch.utils.data import Dataset
 import os

--- a/clinicadl/clinicadl/subject_level/evaluation.py
+++ b/clinicadl/clinicadl/subject_level/evaluation.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 from __future__ import print_function
 import argparse
 import os

--- a/clinicadl/clinicadl/subject_level/evaluation_test.py
+++ b/clinicadl/clinicadl/subject_level/evaluation_test.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 from __future__ import print_function
 import argparse
 import os

--- a/clinicadl/clinicadl/subject_level/resume_CNN.py
+++ b/clinicadl/clinicadl/subject_level/resume_CNN.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 import argparse
 from os import path
 from time import time

--- a/clinicadl/clinicadl/subject_level/resume_autoencoder.py
+++ b/clinicadl/clinicadl/subject_level/resume_autoencoder.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 import argparse
 import torch
 from os import path

--- a/clinicadl/clinicadl/subject_level/train_CNN.py
+++ b/clinicadl/clinicadl/subject_level/train_CNN.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 import argparse
 import torch
 import sys

--- a/clinicadl/clinicadl/subject_level/train_autoencoder.py
+++ b/clinicadl/clinicadl/subject_level/train_autoencoder.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 from __future__ import print_function
 import argparse
 from os import path

--- a/clinicadl/clinicadl/subject_level/utils.py
+++ b/clinicadl/clinicadl/subject_level/utils.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 from __future__ import print_function
 import torch
 import numpy as np

--- a/clinicadl/clinicadl/svm/classification_utils.py
+++ b/clinicadl/clinicadl/svm/classification_utils.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 import abc
 import os
 import pandas as pd

--- a/clinicadl/clinicadl/svm/evaluation.py
+++ b/clinicadl/clinicadl/svm/evaluation.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 import argparse
 import os
 from os import path

--- a/clinicadl/clinicadl/svm/model.py
+++ b/clinicadl/clinicadl/svm/model.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 from os import path
 import numpy as np
 import os

--- a/clinicadl/clinicadl/svm/train.py
+++ b/clinicadl/clinicadl/svm/train.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 import argparse
 import os
 from .classification_utils import extract_indices_from_5_fold

--- a/clinicadl/clinicadl/tools/data/generate_data.py
+++ b/clinicadl/clinicadl/tools/data/generate_data.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 """
 This file generates data for trivial or intractable (random) data for binary classification.
 """

--- a/clinicadl/clinicadl/tools/data/utils.py
+++ b/clinicadl/clinicadl/tools/data/utils.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 import numpy as np
 
 

--- a/clinicadl/clinicadl/tools/deep_learning/data.py
+++ b/clinicadl/clinicadl/tools/deep_learning/data.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 import torch
 import pandas as pd
 import numpy as np

--- a/clinicadl/clinicadl/tools/deep_learning/iotools.py
+++ b/clinicadl/clinicadl/tools/deep_learning/iotools.py
@@ -1,3 +1,4 @@
+# coding: utf8
 
 class Parameters:
     """ Class to define and initialize parameters used in traning CNN networks"""

--- a/clinicadl/clinicadl/tools/deep_learning/models/autoencoder.py
+++ b/clinicadl/clinicadl/tools/deep_learning/models/autoencoder.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 from torch import nn
 import torch
 from copy import deepcopy

--- a/clinicadl/clinicadl/tools/deep_learning/models/iotools.py
+++ b/clinicadl/clinicadl/tools/deep_learning/models/iotools.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 """
 Script containing the iotools for model and optimizer serialization.
 """

--- a/clinicadl/clinicadl/tools/deep_learning/models/modules.py
+++ b/clinicadl/clinicadl/tools/deep_learning/models/modules.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 """
 Class of layers used in the CNN not directly implemented in pytorch.
 """

--- a/clinicadl/clinicadl/tools/deep_learning/models/patch_level.py
+++ b/clinicadl/clinicadl/tools/deep_learning/models/patch_level.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 """
 Script containing the models for the patch level experiments.
 """

--- a/clinicadl/clinicadl/tools/deep_learning/models/slice_level.py
+++ b/clinicadl/clinicadl/tools/deep_learning/models/slice_level.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 import torch.utils.model_zoo as model_zoo
 from torchvision.models.resnet import BasicBlock
 from torch import nn

--- a/clinicadl/clinicadl/tools/deep_learning/models/subject_level.py
+++ b/clinicadl/clinicadl/tools/deep_learning/models/subject_level.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 from .modules import PadMaxPool3d, Flatten
 import torch.nn as nn
 

--- a/clinicadl/clinicadl/tools/tsv/data_formatting.py
+++ b/clinicadl/clinicadl/tools/tsv/data_formatting.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 """
 Source files can be obtained by running the following commands on a BIDS folder:
  - clinica iotools merge-tsv

--- a/clinicadl/clinicadl/tools/tsv/data_split.py
+++ b/clinicadl/clinicadl/tools/tsv/data_split.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 from .tsv_utils import complementary_list, add_demographics, baseline_df, chi2
 from scipy.stats import ttest_ind
 import shutil

--- a/clinicadl/clinicadl/tools/tsv/kfold_split.py
+++ b/clinicadl/clinicadl/tools/tsv/kfold_split.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 from .tsv_utils import baseline_df
 import shutil
 from sklearn.model_selection import StratifiedKFold

--- a/clinicadl/clinicadl/tools/tsv/restriction_AIBL.py
+++ b/clinicadl/clinicadl/tools/tsv/restriction_AIBL.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 import argparse
 import pandas as pd
 from copy import deepcopy

--- a/clinicadl/clinicadl/tools/tsv/restriction_OASIS.py
+++ b/clinicadl/clinicadl/tools/tsv/restriction_OASIS.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 import argparse
 import pandas as pd
 

--- a/clinicadl/clinicadl/tools/tsv/test.py
+++ b/clinicadl/clinicadl/tools/tsv/test.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 """
 Check the absence of data leakage
     1) Baseline datasets contain only one scan per subject

--- a/clinicadl/clinicadl/tools/tsv/tsv_utils.py
+++ b/clinicadl/clinicadl/tools/tsv/tsv_utils.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 from copy import copy
 import numpy as np
 import pandas as pd

--- a/clinicadl/tests/test_cli.py
+++ b/clinicadl/tests/test_cli.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 import pytest
 import clinicadl.cli as cli
 from clinicadl.tools.deep_learning.iotools import Parameters

--- a/clinicadl/tests/test_preprocessing.py
+++ b/clinicadl/tests/test_preprocessing.py
@@ -1,3 +1,5 @@
+# coding: utf8
+
 from clinicadl.preprocessing.T1_lineal import preprocessing_t1w
 
 bids_dir =


### PR DESCRIPTION
Hi,

I fixed some typos on the Readme & CLI while UTF-8 encoding on several headers.

Best,
Alex