### PR TITLE
Change behaviour of split variable

### DIFF
--- a/clinicadl/clinicadl/cli.py
+++ b/clinicadl/clinicadl/cli.py
@@ -691,8 +691,8 @@ def parse_command_line():
         type=int, default=None)
     train_cv_group.add_argument(
         '--split',
-        help='Will load the specific split wanted.',
-        type=int, default=0)
+        help='Train the list of given folds. By default train all folds.',
+        type=int, default=None, nargs='+')
 
     # Optimization parameters
     train_optim_group = train_parent_parser.add_argument_group(

--- a/clinicadl/clinicadl/image_level/evaluation.py
+++ b/clinicadl/clinicadl/image_level/evaluation.py
@@ -16,7 +16,7 @@ from ..tools.deep_learning import create_model, load_model, read_json
 def test_cnn(data_loader, subset_name, split, criterion, options):
 
     best_model_dir = os.path.join(options.model_path, 'best_model_dir')
-    json_path = path.join(options.model_path, 'log_dir', 'fold_' + str(split), "commandline_cnn.json")
+    json_path = path.join(options.model_path, "commandline_cnn.json")
     options = read_json(options, "cnn", json_path=json_path)
 
     for selection in ["best_acc", "best_loss"]:

--- a/clinicadl/clinicadl/image_level/evaluation_test.py
+++ b/clinicadl/clinicadl/image_level/evaluation_test.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
         split = int(fold_dir[-1])
         print("Fold %i" % split)
         model_options = argparse.Namespace()
-        json_path = path.join(options.model_path, 'log_dir', 'fold_' + str(split), "commandline_CNN.json")
+        json_path = path.join(options.model_path, "commandline_CNN.json")
         model_options = read_json(model_options, "CNN", json_path=json_path)
         model = create_model(model_options.network, options.gpu)
 

--- a/clinicadl/clinicadl/image_level/resume_CNN.py
+++ b/clinicadl/clinicadl/image_level/resume_CNN.py
@@ -77,7 +77,7 @@ def main(options):
 
     print('Resuming the training task')
 
-    train(model, train_loader, valid_loader, criterion, optimizer, True, options)
+    train(model, train_loader, valid_loader, criterion, optimizer, True, options.split, options)
 
     total_time = time() - total_time
     print("Total time of computation: %d s" % total_time)

--- a/clinicadl/clinicadl/image_level/resume_CNN.py
+++ b/clinicadl/clinicadl/image_level/resume_CNN.py
@@ -75,9 +75,12 @@ def main(options):
     optimizer_path = path.join(options.model_path, 'optimizer.pth.tar')
     optimizer = load_optimizer(optimizer_path, model)
 
-    print('Resuming the training task')
+    # Define output directories
+    log_dir = path.join(options.output_dir, 'log_dir', 'fold_%i' % options.split, 'CNN')
+    model_dir = path.join(options.output_dir, 'best_model_dir', 'fold_%i' % options.split, 'CNN')
 
-    train(model, train_loader, valid_loader, criterion, optimizer, True, options.split, options)
+    print('Resuming the training task')
+    train(model, train_loader, valid_loader, criterion, optimizer, True, log_dir, model_dir, options)
 
     total_time = time() - total_time
     print("Total time of computation: %d s" % total_time)

--- a/clinicadl/clinicadl/image_level/resume_autoencoder.py
+++ b/clinicadl/clinicadl/image_level/resume_autoencoder.py
@@ -79,7 +79,7 @@ def main(options):
 
     print('Resuming the training task')
 
-    ae_finetuning(decoder, train_loader, valid_loader, criterion, optimizer, True, options)
+    ae_finetuning(decoder, train_loader, valid_loader, criterion, optimizer, True, options.split, options)
 
     total_time = time() - total_time
     print("Total time of computation: %d s" % total_time)

--- a/clinicadl/clinicadl/image_level/resume_autoencoder.py
+++ b/clinicadl/clinicadl/image_level/resume_autoencoder.py
@@ -77,9 +77,14 @@ def main(options):
     optimizer_path = path.join(options.model_path, 'optimizer.pth.tar')
     optimizer = load_optimizer(optimizer_path, decoder)
 
-    print('Resuming the training task')
+    # Define output directories
+    log_dir = path.join(options.output_dir, 'log_dir', 'fold_%i' % options.split, 'ConvAutoencoder')
+    visualization_dir = path.join(options.output_dir, 'visualize', 'fold_%i' % options.split)
+    model_dir = path.join(options.output_dir, 'best_model_dir', 'fold_%i' % options.split, 'ConvAutoencoder')
 
-    ae_finetuning(decoder, train_loader, valid_loader, criterion, optimizer, True, options.split, options)
+    print('Resuming the training task')
+    ae_finetuning(decoder, train_loader, valid_loader, criterion, optimizer, True,
+                  log_dir, model_dir, visualization_dir, options)
 
     total_time = time() - total_time
     print("Total time of computation: %d s" % total_time)

--- a/clinicadl/clinicadl/image_level/train_CNN.py
+++ b/clinicadl/clinicadl/image_level/train_CNN.py
@@ -60,17 +60,17 @@ def train_cnn(params):
                                             params.baseline)
 
         data_train = MRIDataset(
-                params.input_dir,
-                training_tsv,
-                params.preprocessing,
-                transform=transformations
-                )
+            params.input_dir,
+            training_tsv,
+            params.preprocessing,
+            transform=transformations
+        )
         data_valid = MRIDataset(
-                params.input_dir,
-                valid_tsv,
-                params.preprocessing,
-                transform=transformations
-                )
+            params.input_dir,
+            valid_tsv,
+            params.preprocessing,
+            transform=transformations
+        )
 
         # Use argument load to distinguish training and testing
         train_loader = DataLoader(data_train,

--- a/clinicadl/clinicadl/image_level/train_CNN.py
+++ b/clinicadl/clinicadl/image_level/train_CNN.py
@@ -52,7 +52,6 @@ def train_cnn(params):
         fold_iterator = params.split
 
     for fold in fold_iterator:
-        print("Test 1, fold " + str(fold), params.dropout)
 
         # Get the data.
         training_tsv, valid_tsv = load_data(params.tsv_path, params.diagnoses,
@@ -94,22 +93,18 @@ def train_cnn(params):
         model = transfer_learning(model, fold, params.output_dir, source_path=params.transfer_learning_path,
                                   transfer_learning_autoencoder=params.transfer_learning_autoencoder,
                                   gpu=params.gpu, selection=params.selection)
-        print("Test 2, fold " + str(fold), params.dropout)
 
         # Define criterion and optimizer
         criterion = torch.nn.CrossEntropyLoss()
         optimizer = eval("torch.optim." + params.optimizer)(filter(lambda x: x.requires_grad, model.parameters()),
                                                             lr=params.learning_rate,
                                                             weight_decay=params.weight_decay)
-        print("Test 3, fold " + str(fold), params.dropout)
 
-        print('Beginning the training task')
         train(model, train_loader, valid_loader, criterion, optimizer, False, fold, params)
 
         params.model_path = params.output_dir
         test_cnn(train_loader, "train", fold, criterion, params)
         test_cnn(valid_loader, "validation", fold, criterion, params)
-        print("Test 4, fold " + str(fold), params.dropout)
 
     total_time = time() - total_time
     print("Total time of computation: %d s" % total_time)

--- a/clinicadl/clinicadl/image_level/train_CNN.py
+++ b/clinicadl/clinicadl/image_level/train_CNN.py
@@ -100,7 +100,11 @@ def train_cnn(params):
                                                             lr=params.learning_rate,
                                                             weight_decay=params.weight_decay)
 
-        train(model, train_loader, valid_loader, criterion, optimizer, False, fold, params)
+        # Define output directories
+        log_dir = path.join(params.output_dir, 'log_dir', 'fold_%i' % fold, 'CNN')
+        model_dir = path.join(params.output_dir, 'best_model_dir', 'fold_%i' % fold, 'CNN')
+
+        train(model, train_loader, valid_loader, criterion, optimizer, False, log_dir, model_dir, params)
 
         params.model_path = params.output_dir
         test_cnn(train_loader, "train", fold, criterion, params)

--- a/clinicadl/clinicadl/image_level/train_autoencoder.py
+++ b/clinicadl/clinicadl/image_level/train_autoencoder.py
@@ -82,7 +82,13 @@ def train_autoencoder(params):
                 decoder.decoder = nn.Sequential(*list(decoder.decoder)[:-1])
             decoder.decoder.add_module("sigmoid", nn.Sigmoid())
 
-        ae_finetuning(decoder, train_loader, valid_loader, criterion, optimizer, False, params)
+        # Define output directories
+        log_dir = path.join(params.output_dir, 'log_dir', 'fold_%i' % fold, 'ConvAutoencoder')
+        visualization_dir = path.join(params.output_dir, 'visualize', 'fold_%i' % fold)
+        model_dir = path.join(params.output_dir, 'best_model_dir', 'fold_%i' % fold, 'ConvAutoencoder')
+
+        ae_finetuning(decoder, train_loader, valid_loader, criterion, optimizer, False,
+                      log_dir, model_dir, visualization_dir, params)
 
     total_time = time() - total_time
     print('Total time', total_time)

--- a/clinicadl/clinicadl/image_level/utils.py
+++ b/clinicadl/clinicadl/image_level/utils.py
@@ -16,7 +16,7 @@ from clinicadl.tools.deep_learning import EarlyStopping, save_checkpoint
 # CNN train / test  #
 #####################
 
-def train(model, train_loader, valid_loader, criterion, optimizer, resume, options):
+def train(model, train_loader, valid_loader, criterion, optimizer, resume, split, options):
     """
     Function used to train a CNN.
     The best model and checkpoint will be found in the 'best_model_dir' of options.output_dir.
@@ -27,14 +27,15 @@ def train(model, train_loader, valid_loader, criterion, optimizer, resume, optio
     :param criterion: (loss) function to calculate the loss
     :param optimizer: (torch.optim) optimizer linked to model parameters
     :param resume: (bool) if True, a begun job is resumed
+    :param split: (int) Number of the split that is trained
     :param options: (Namespace) ensemble of other options given to the main script.
     """
     from tensorboardX import SummaryWriter
     from time import time
 
     columns = ['epoch', 'iteration', 'acc_train', 'mean_loss_train', 'acc_valid', 'mean_loss_valid', 'time']
-    log_dir = os.path.join(options.output_dir, 'log_dir', 'fold_' + str(options.split), 'CNN')
-    best_model_dir = os.path.join(options.output_dir, 'best_model_dir', 'fold_' + str(options.split), 'CNN')
+    log_dir = os.path.join(options.output_dir, 'log_dir', 'fold_%i' % split, 'CNN')
+    best_model_dir = os.path.join(options.output_dir, 'best_model_dir', 'fold_%i' % split, 'CNN')
     filename = os.path.join(log_dir, 'training.tsv')
 
     if not resume:
@@ -297,7 +298,7 @@ def test(model, dataloader, use_cuda, criterion, full_return=False):
 # AutoEncoder train / test  #
 #############################
 
-def ae_finetuning(decoder, train_loader, valid_loader, criterion, optimizer, resume, options):
+def ae_finetuning(decoder, train_loader, valid_loader, criterion, optimizer, resume, split, options):
     """
     Function used to train an autoencoder.
     The best autoencoder and checkpoint will be found in the 'best_model_dir' of options.output_dir.
@@ -308,13 +309,14 @@ def ae_finetuning(decoder, train_loader, valid_loader, criterion, optimizer, res
     :param criterion: (loss) function to calculate the loss.
     :param optimizer: (torch.optim) optimizer linked to model parameters.
     :param resume: (bool) if True, a begun job is resumed.
+    :param split: (int) Number of the split that is trained
     :param options: (Namespace) ensemble of other options given to the main script.
     """
     from tensorboardX import SummaryWriter
 
-    log_dir = os.path.join(options.output_dir, 'log_dir', 'fold_' + str(options.split), 'ConvAutoencoder')
-    visualization_path = os.path.join(options.output_dir, 'visualize', 'fold_' + str(options.split))
-    best_model_dir = os.path.join(options.output_dir, 'best_model_dir', 'fold_' + str(options.split), 'ConvAutoencoder')
+    log_dir = os.path.join(options.output_dir, 'log_dir', 'fold_%i' % split, 'ConvAutoencoder')
+    visualization_path = os.path.join(options.output_dir, 'visualize', 'fold_%i' % split)
+    best_model_dir = os.path.join(options.output_dir, 'best_model_dir', 'fold_%i' % split, 'ConvAutoencoder')
     filename = os.path.join(log_dir, 'training.tsv')
 
     if not resume:

--- a/clinicadl/clinicadl/patch_level/evaluation_multiCNN.py
+++ b/clinicadl/clinicadl/patch_level/evaluation_multiCNN.py
@@ -81,7 +81,7 @@ def main(options):
     if options.split is None:
         fold_iterator = range(options.n_splits)
     else:
-        fold_iterator = [options.split]
+        fold_iterator = options.split
 
     # Loop on folds
     for fi in fold_iterator:

--- a/clinicadl/clinicadl/patch_level/evaluation_singleCNN.py
+++ b/clinicadl/clinicadl/patch_level/evaluation_singleCNN.py
@@ -84,7 +84,7 @@ def main(options):
     if options.split is None:
         fold_iterator = range(options.n_splits)
     else:
-        fold_iterator = [options.split]
+        fold_iterator = options.split
 
     # Loop on folds
     for fi in fold_iterator:

--- a/clinicadl/clinicadl/patch_level/train_autoencoder.py
+++ b/clinicadl/clinicadl/patch_level/train_autoencoder.py
@@ -25,7 +25,7 @@ def train_autoencoder_patch(params):
     if params.split is None:
         fold_iterator = range(params.n_splits)
     else:
-        fold_iterator = [params.split]
+        fold_iterator = params.split
 
     for fi in fold_iterator:
 

--- a/clinicadl/clinicadl/patch_level/train_multiCNN.py
+++ b/clinicadl/clinicadl/patch_level/train_multiCNN.py
@@ -39,7 +39,7 @@ def train_patch_multi_cnn(params):
     if params.split is None:
         fold_iterator = range(params.n_splits)
     else:
-        fold_iterator = [params.split]
+        fold_iterator = params.split
 
     # Loop on folds
     for fi in fold_iterator:

--- a/clinicadl/clinicadl/patch_level/train_singleCNN.py
+++ b/clinicadl/clinicadl/patch_level/train_singleCNN.py
@@ -40,7 +40,7 @@ def train_patch_single_cnn(params):
     if params.split is None:
         fold_iterator = range(params.n_splits)
     else:
-        fold_iterator = [params.split]
+        fold_iterator = params.split
 
     for fi in fold_iterator:
 

--- a/clinicadl/clinicadl/slice_level/train_CNN.py
+++ b/clinicadl/clinicadl/slice_level/train_CNN.py
@@ -57,7 +57,7 @@ def train_slice(params):
     if params.split is None:
         fold_iterator = range(params.n_splits)
     else:
-        fold_iterator = [params.split]
+        fold_iterator = params.split
 
     for fi in fold_iterator:
 

--- a/clinicadl/clinicadl/tools/deep_learning/iotools.py
+++ b/clinicadl/clinicadl/tools/deep_learning/iotools.py
@@ -158,12 +158,8 @@ def commandline_to_json(commandline, task_type):
     commandline_arg_dic['unknown_arg'] = commandline[1]
 
     output_dir = commandline_arg_dic['output_dir']
-    if commandline_arg_dic['split'] is None:
-        log_dir = os.path.join(output_dir, 'log_dir')
-    else:
-        log_dir = os.path.join(output_dir, 'log_dir', 'fold_' + str(commandline_arg_dic['split']))
-    if not os.path.exists(log_dir):
-        os.makedirs(log_dir)
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
 
     # remove these entries from the commandline log file
     if 'func' in commandline_arg_dic:
@@ -180,8 +176,8 @@ def commandline_to_json(commandline, task_type):
 
     # save to json file
     json = json.dumps(commandline_arg_dic, skipkeys=True)
-    print("Path of json file:", os.path.join(log_dir, "commandline_" + task_type + ".json"))
-    f = open(os.path.join(log_dir, "commandline_" + task_type + ".json"), "w")
+    print("Path of json file:", os.path.join(output_dir, "commandline_" + task_type + ".json"))
+    f = open(os.path.join(output_dir, "commandline_" + task_type + ".json"), "w")
     f.write(json)
     f.close()
 
@@ -195,11 +191,12 @@ def read_json(options, task_type, json_path=None, test=False):
     """
     import json
     from os import path
+    from ...cli import set_default_dropout
 
     evaluation_parameters = ["diagnosis_path", "input_dir", "diagnoses"]
     prep_compatibility_dict = {"mni": "t1-volume", "linear": "t1-linear"}
     if json_path is None:
-        json_path = path.join(options.model_path, 'log_dir', 'commandline_' + task_type + '.json')
+        json_path = path.join(options.model_path, 'commandline_' + task_type + '.json')
 
     with open(json_path, "r") as f:
         json_data = json.load(f)
@@ -216,7 +213,8 @@ def read_json(options, task_type, json_path=None, test=False):
 
     # Retro-compatibility with runs of previous versions
     if not hasattr(options, 'dropout'):
-        options.dropout = 0
+        options.dropout = None
+    set_default_dropout(options)
 
     if options.preprocessing in prep_compatibility_dict.keys():
         options.preprocessing = prep_compatibility_dict[options.preprocessing]


### PR DESCRIPTION
This PR closes https://github.com/aramis-lab/AD-DL/issues/25.

`split` is now a list of folds that are executed (default behaviour, all splits are trained).
As one run may correspond to several folds, the json file was moved at the root.