### PR TITLE
Rename patch/slice files from extract task

### DIFF
--- a/clinicadl/clinicadl/cli.py
+++ b/clinicadl/clinicadl/cli.py
@@ -590,10 +590,10 @@ def parse_command_line():
     extract_parser.add_argument(
         'extract_method',
         help='''Method used to extract features. Three options:
-             'slice' to get 2D slices from the MRI,
-             'patch' to get 3D volumetric patches or
-             'whole' to get the complete MRI.''',
-        choices=['slice', 'patch', 'whole'], default='whole')
+             'image' to conver to PyTorch tensor the complete 3D image,
+             'patch' to extract 3D volumetric patches or
+             'slice' to get 2D slices from the image.''',
+        choices=['image', 'patch', 'slice'], default='image')
     extract_parser.add_argument(
         '-ps', '--patch_size',
         help='''Patch size (only for 'patch' extraction) e.g: --patch_size 50''',
@@ -612,9 +612,9 @@ def parse_command_line():
     extract_parser.add_argument(
         '-sm', '--slice_mode',
         help='''Slice mode (only for 'slice' extraction). Two options:
-             'original' to save one single channel (intensity),
-             'rgb' to saves three channel (with same intensity).''',
-        choices=['original', 'rgb'], default='rgb')
+             'single' to save the slice in one single channel,
+             'rgb' to save the slice in three identical channel.''',
+        choices=['single', 'rgb'], default='rgb')
     extract_parser.add_argument(
         '-np', '--nproc',
         help='Number of cores used for processing',

--- a/clinicadl/clinicadl/preprocessing/T1_preparedl.py
+++ b/clinicadl/clinicadl/preprocessing/T1_preparedl.py
@@ -4,11 +4,11 @@
 def extract_dl_t1w(caps_directory,
                    tsv,
                    working_directory=None,
-                   extract_method='whole',
+                   extract_method='image',
                    patch_size=50,
                    stride_size=50,
                    slice_direction=0,
-                   slice_mode='original'):
+                   slice_mode='single'):
     """ This is a preprocessing pipeline to convert the MRIs in nii.gz format
     into tensor versions (using pytorch format). It also prepares the
     slice-level and patch-level data from the entire MRI and save them on disk.
@@ -28,9 +28,9 @@ def extract_dl_t1w(caps_directory,
       TVS file with the subject list (participant_id and session_id).
     extract_method:
       Select which extract method will be applied for the outputs:
-      - 'slice' to get slices from the MRI,
-      - 'patch' to get 3D patches from MRI,
-      - 'whole' to get the complete MRI
+      - 'image' to convert to PyTorch tensor the complete 3D image,
+      - 'patch' to extract 3D volumetric patches and
+      - 'slice' to extract 2D slices from the image
     patch_size: int
       Size for extracted 3D patches (only 'patch' method).
     stride_size: int
@@ -42,8 +42,8 @@ def extract_dl_t1w(caps_directory,
       - 2: Axial plane
     slice_mode: str
       Mode how slices are stored (only 'slice' method):
-      - original: saves one single channel (intensity)
-      - rgb: saves with three channels (red, green, blue)
+      - single: saves the slice in a single channel, 
+      - rgb: saves the slice in three identical  channels (red, green, blue)
     working_directory: str
       Folder containing a temporary space to save intermediate results.
     e

--- a/clinicadl/clinicadl/preprocessing/T1_preparedl.py
+++ b/clinicadl/clinicadl/preprocessing/T1_preparedl.py
@@ -161,11 +161,11 @@ def extract_dl_t1w(caps_directory,
     # ----------------------
     extract_slices = npe.MapNode(
             name='extract_slices',
-            iterfield=['preprocessed_T1'],
+            iterfield=['input_tensor'],
             interface=nutil.Function(
                 function=extract_slices,
                 input_names=[
-                    'preprocessed_T1', 'slice_direction',
+                    'input_tensor', 'slice_direction',
                     'slice_mode'
                     ],
                 output_names=['output_file_rgb', 'output_file_original']
@@ -179,10 +179,10 @@ def extract_dl_t1w(caps_directory,
     # ----------------------
     extract_patches = npe.MapNode(
             name='extract_patches',
-            iterfield=['preprocessed_T1'],
+            iterfield=['input_tensor'],
             interface=nutil.Function(
                 function=extract_patches,
-                input_names=['preprocessed_T1', 'patch_size', 'stride_size'],
+                input_names=['input_tensor', 'patch_size', 'stride_size'],
                 output_names=['output_patch']
                 )
             )
@@ -232,14 +232,14 @@ def extract_dl_t1w(caps_directory,
     if extract_method == 'slice':
         subfolder = 'slice_based'
         wf.connect([
-            (save_as_pt, extract_slices, [('output_file', 'preprocessed_T1')]),
+            (save_as_pt, extract_slices, [('output_file', 'input_tensor')]),
             (extract_slices, write_node, [('output_file_rgb', '@slices_rgb_T1')]),
             (extract_slices, write_node, [('output_file_original', '@slices_original_T1')])
             ])
     elif extract_method == 'patch':
         subfolder = 'patch_based'
         wf.connect([
-            (save_as_pt, extract_patches, [('output_file', 'preprocessed_T1')]),
+            (save_as_pt, extract_patches, [('output_file', 'input_tensor')]),
             (extract_patches, write_node, [('output_patch', '@patches_T1')])
             ])
     else:

--- a/clinicadl/clinicadl/preprocessing/T1_preparedl.py
+++ b/clinicadl/clinicadl/preprocessing/T1_preparedl.py
@@ -42,7 +42,7 @@ def extract_dl_t1w(caps_directory,
       - 2: Axial plane
     slice_mode: str
       Mode how slices are stored (only 'slice' method):
-      - single: saves the slice in a single channel, 
+      - single: saves the slice in a single channel,
       - rgb: saves the slice in three identical  channels (red, green, blue)
     working_directory: str
       Folder containing a temporary space to save intermediate results.

--- a/clinicadl/clinicadl/preprocessing/T1_preparedl_utils.py
+++ b/clinicadl/clinicadl/preprocessing/T1_preparedl_utils.py
@@ -2,14 +2,14 @@
 
 def extract_slices(input_tensor, slice_direction=0, slice_mode='single'):
     """Extracts the slices from three directions
-    
+
     This function extracts slices form the preprocesed nifti image.  The
     direction of extraction can be defined either on sagital direction (0),
     cornal direction (1) or axial direction (other). The output slices can be
     stores following two modes: single (1 channel) ou RGB (3 channels, all the
     same).
 
-    
+
     Args:
         input_tensor: tensor version of the nifti MRI.
         slice_direction: which axis direction that the slices were extracted
@@ -34,11 +34,11 @@ def extract_slices(input_tensor, slice_direction=0, slice_mode='single'):
 
     basedir = os.getcwd()
     input_tensor_filename = os.path.basename(input_tensor)
-    
+
     txt_idx = input_tensor_filename.rfind("_")
     it_filename_prefix = input_tensor_filename[0:txt_idx]
     it_filename_suffix = input_tensor_filename[txt_idx:]
-    
+
     output_file_original = []
     output_file_rgb = []
     if slice_direction == 0:
@@ -62,7 +62,7 @@ def extract_slices(input_tensor, slice_direction=0, slice_mode='single'):
                             + '_axis-sag_channel-single_slice-'
                             + str(index_slice)
                             + it_filename_suffix
-                            )
+                        )
                         )
                 torch.save(extracted_slice_original_sag.clone(), output_file_original[index_slice_list])
             elif slice_mode == 'rgb':
@@ -73,7 +73,7 @@ def extract_slices(input_tensor, slice_direction=0, slice_mode='single'):
                             + '_axis-sag_channel-rgb_slice-'
                             + str(index_slice)
                             + it_filename_suffix
-                            )
+                        )
                         )
                 torch.save(extracted_slice_rgb_sag.clone(), output_file_rgb[index_slice_list])
 
@@ -94,14 +94,14 @@ def extract_slices(input_tensor, slice_direction=0, slice_mode='single'):
             # save into .pt format
             if slice_mode == 'single':
                 output_file_original.append(
-                        os.path.join(
-                            basedir,
-                            it_filename_prefix
-                            + '_axis-cor_channel-single_slice-'
-                            + str(index_slice)
-                            + it_filename_suffix
-                            )
-                        )
+                    os.path.join(
+                        basedir,
+                        it_filename_prefix
+                        + '_axis-cor_channel-single_slice-'
+                        + str(index_slice)
+                        + it_filename_suffix
+                    )
+                )
                 torch.save(extracted_slice_original_cor.clone(), output_file_original[index_slice_list])
             elif slice_mode == 'rgb':
                 output_file_rgb.append(
@@ -111,8 +111,8 @@ def extract_slices(input_tensor, slice_direction=0, slice_mode='single'):
                         + '_axis-cor_channel-rgb_slice-'
                         + str(index_slice)
                         + it_filename_suffix
-                        )
                     )
+                )
                 torch.save(extracted_slice_rgb_cor.clone(), output_file_rgb[index_slice_list])
 
     else:
@@ -139,7 +139,7 @@ def extract_slices(input_tensor, slice_direction=0, slice_mode='single'):
                             + '_axis-axi_channel-single_slice-'
                             + str(index_slice)
                             + it_filename_suffix
-                            )
+                        )
                         )
                 torch.save(extracted_slice_original_axi.clone(), output_file_original[index_slice_list])
             elif slice_mode == 'rgb':
@@ -150,7 +150,7 @@ def extract_slices(input_tensor, slice_direction=0, slice_mode='single'):
                             + '_axis-axi_channel-rgb_slice-'
                             + str(index_slice)
                             + it_filename_suffix
-                            )
+                        )
                         )
                 torch.save(extracted_slice_rgb_axi.clone(), output_file_rgb[index_slice_list])
 
@@ -159,13 +159,13 @@ def extract_slices(input_tensor, slice_direction=0, slice_mode='single'):
 
 def extract_patches(input_tensor, patch_size, stride_size):
     """Extracts the patches
-    
+
     This function extracts patches form the preprocesed nifti image. Patch size
     if provieded as input and also the stride size. If stride size is smaller
     than the patch size an overlap exist between consecutive patches. If stride
     size is equal to path size there is no overlap. Otherwise, unprocessed
     zones can exits.
-    
+
     Args:
         input_tensor: tensor version of the nifti MRI.
         patch_size: size of a single patch.
@@ -185,7 +185,7 @@ def extract_patches(input_tensor, patch_size, stride_size):
     patches_tensor = image_tensor.unfold(1, patch_size, stride_size).unfold(2, patch_size, stride_size).unfold(3, patch_size, stride_size).contiguous()
     # the dimension of patch_tensor should be [1, patch_num1, patch_num2, patch_num3, patch_size1, patch_size2, patch_size3]
     patches_tensor = patches_tensor.view(-1, patch_size, patch_size, patch_size)
-    
+
     input_tensor_filename = os.path.basename(input_tensor)
     txt_idx = input_tensor_filename.rfind("_")
     it_filename_prefix = input_tensor_filename[0:txt_idx]
@@ -206,7 +206,7 @@ def extract_patches(input_tensor, patch_size, stride_size):
                     + '_patch-'
                     + str(index_patch)
                     + it_filename_suffix
-                    )
+                )
                 )
         torch.save(extracted_patch.clone(), output_patch[index_patch])
 
@@ -215,10 +215,10 @@ def extract_patches(input_tensor, patch_size, stride_size):
 
 def save_as_pt(input_img):
     """Saves PyTorch tensor version of the nifti image
-    
+
     This function convert nifti image to tensor (.pt) version of the image.
     Tensor version is saved at the same location than input_img.
-    
+
     Args:
         input_tensor: tensor version of the nifti MRI.
 

--- a/clinicadl/clinicadl/tools/deep_learning/data.py
+++ b/clinicadl/clinicadl/tools/deep_learning/data.py
@@ -173,10 +173,10 @@ class MRIDataset_patch(Dataset):
             patch_path = path.join(self.caps_directory, 'subjects', img_name, sess_name,
                                    'deeplearning_prepare_data', 'patch_based', 't1_linear',
                                    img_name + '_' + sess_name
-                                   + FILENAME_TYPE['cropped']
+                                   + FILENAME_TYPE['cropped'][0:-4]
                                    + '_patchsize-' + str(self.patch_size)
                                    + '_stride-' + str(self.stride_size)
-                                   + '_patch-' + str(patch_idx) + '.pt')
+                                   + '_patch-' + str(patch_idx) + '_T1w.pt')
 
             patch = torch.load(patch_path)
         else:
@@ -393,8 +393,9 @@ class MRIDataset_slice(Dataset):
             slice_path = path.join(self.caps_directory, 'subjects', img_name, sess_name,
                                    'deeplearning_prepare_data', 'slice_based', 't1_linear',
                                    img_name + '_' + sess_name
-                                   + FILENAME_TYPE['cropped']
-                                   + self.slice_direction + '_rgbslice-%i.pt' % slice_idx)
+                                   + FILENAME_TYPE['cropped'][0:-4]
+                                   + '_axis-' + self.slice_direction 
+                                   + '_channel-rgb_slice-%i_T1w.pt' % slice_idx)
             extracted_slice = torch.load(slice_path)
         else:
             image_path = path.join(self.caps_directory, 'subjects', img_name, sess_name,
@@ -484,8 +485,9 @@ class MRIDataset_slice_mixed(Dataset):
             slice_path = path.join(self.caps_directory, 'subjects', img_name, sess_name,
                                    'deeplearning_prepare_data', 'slice_based', 't1_linear',
                                    img_name + '_' + sess_name
-                                   + FILENAME_TYPE['cropped']
-                                   + self.slice_direction + '_rgbslice-' + str(slice_name) + '.pt')
+                                   + FILENAME_TYPE['cropped'][0:-4]
+                                   + '_axis-' + self.slice_direction 
+                                   + '_channel-rgb_slice-' + str(slice_name) + '_T1w.pt')
             extracted_slice = torch.load(slice_path)
 
         else:

--- a/clinicadl/clinicadl/tools/deep_learning/data.py
+++ b/clinicadl/clinicadl/tools/deep_learning/data.py
@@ -394,7 +394,7 @@ class MRIDataset_slice(Dataset):
                                    'deeplearning_prepare_data', 'slice_based', 't1_linear',
                                    img_name + '_' + sess_name
                                    + FILENAME_TYPE['cropped'][0:-4]
-                                   + '_axis-' + self.slice_direction 
+                                   + '_axis-' + self.slice_direction
                                    + '_channel-rgb_slice-%i_T1w.pt' % slice_idx)
             extracted_slice = torch.load(slice_path)
         else:
@@ -486,7 +486,7 @@ class MRIDataset_slice_mixed(Dataset):
                                    'deeplearning_prepare_data', 'slice_based', 't1_linear',
                                    img_name + '_' + sess_name
                                    + FILENAME_TYPE['cropped'][0:-4]
-                                   + '_axis-' + self.slice_direction 
+                                   + '_axis-' + self.slice_direction
                                    + '_channel-rgb_slice-' + str(slice_name) + '_T1w.pt')
             extracted_slice = torch.load(slice_path)
 


### PR DESCRIPTION
Rename files produced by `extract patch` and `extract slice` in order to be coherent with naming in Clinica deeplearning-prepare-data pipeline.