### PR TITLE
Rearrange train outputs

### DIFF
--- a/clinicadl/clinicadl/classify/inference.py
+++ b/clinicadl/clinicadl/classify/inference.py
@@ -43,7 +43,6 @@ def classify(caps_dir,
         print("Folder containing MRIs was not found, please verify its location.")
         raise FileNotFoundError(
             errno.ENOENT, strerror(errno.ENOENT), caps_dir)
-        print("Folder containing MRIs is not found, please verify its location")
     if not isdir(model_path):
         print("A valid model in the path was not found. Donwload them from aramislab.inria.fr")
         raise FileNotFoundError(
@@ -129,7 +128,7 @@ def inference_from_model(caps_dir,
     parser.add_argument("model_path", type=str,
                         help="Path to the trained model folder.")
     options = parser.parse_args([model_path])
-    options = read_json(options, "CNN", json_path=json_file)
+    options = read_json(options, json_path=json_file)
     print("Load model with these options:")
     print(options)
 
@@ -138,8 +137,8 @@ def inference_from_model(caps_dir,
     options.prepare_dl = prepare_dl
     # Define the path
     currentDirectory = pathlib.Path(model_path)
-    # Search for 'fold_*' pattern
-    currentPattern = "fold_*"
+    # Search for 'fold-*' pattern
+    currentPattern = "fold-*"
 
     best_model = {
         'best_acc': 'best_balanced_accuracy',
@@ -148,7 +147,6 @@ def inference_from_model(caps_dir,
 
     # loop depending the number of folds found in the model folder
     for fold_dir in currentDirectory.glob(currentPattern):
-        split = int(str(fold_dir)[-1])
         fold_path = join(model_path, fold_dir)
         models_path = join(fold_path, 'models')
         full_model_path = join(models_path, best_model['best_acc'])

--- a/clinicadl/clinicadl/cli.py
+++ b/clinicadl/clinicadl/cli.py
@@ -808,7 +808,7 @@ def parse_command_line():
     train_image_cnn_parser._action_groups[-1].add_argument(
         '--transfer_learning_selection',
         help="If transfer_learning from CNN, chooses which best transfer model is selected.",
-        type=str, default="best_acc", choices=["best_loss", "best_acc"])
+        type=str, default="best_balanced_accuracy", choices=["best_loss", "best_balanced_accuracy"])
 
     train_image_cnn_parser.set_defaults(func=train_func)
 
@@ -861,7 +861,7 @@ def parse_command_line():
     train_patch_cnn_parser._action_groups[-1].add_argument(
         '--transfer_learning_selection',
         help="If transfer_learning from CNN, chooses which best transfer model is selected.",
-        type=str, default="best_acc", choices=["best_loss", "best_acc"])
+        type=str, default="best_balanced_accuracy", choices=["best_loss", "best_balanced_accuracy"])
 
     train_patch_cnn_group = train_patch_cnn_parser.add_argument_group(
         TRAIN_CATEGORIES["PATCH CNN"])
@@ -885,7 +885,7 @@ def parse_command_line():
     train_patch_multicnn_parser._action_groups[-1].add_argument(
         '--transfer_learning_selection',
         help="If transfer_learning from CNN, chooses which best transfer model is selected.",
-        type=str, default="best_acc", choices=["best_loss", "best_acc"])
+        type=str, default="best_balanced_accuracy", choices=["best_loss", "best_balanced_accuracy"])
 
     train_patch_multicnn_group = train_patch_multicnn_parser.add_argument_group(
         TRAIN_CATEGORIES["PATCH CNN"])

--- a/clinicadl/clinicadl/cli.py
+++ b/clinicadl/clinicadl/cli.py
@@ -153,7 +153,6 @@ def train_func(args):
                 evaluation_steps=args.evaluation_steps,
                 num_workers=args.nproc,
                 transfer_learning_path=args.transfer_learning_path,
-                transfer_learning_autoencoder=args.transfer_learning_autoencoder,
                 transfer_learning_selection=args.transfer_learning_selection
             )
             train_single_cnn(train_params_cnn)
@@ -253,7 +252,6 @@ def train_func(args):
                 evaluation_steps=args.evaluation_steps,
                 num_workers=args.nproc,
                 transfer_learning_path=args.transfer_learning_path,
-                transfer_learning_autoencoder=args.transfer_learning_autoencoder,
                 transfer_learning_selection=args.transfer_learning_selection,
                 patch_size=args.patch_size,
                 stride_size=args.stride_size,
@@ -290,7 +288,6 @@ def train_func(args):
                 evaluation_steps=args.evaluation_steps,
                 num_workers=args.nproc,
                 transfer_learning_path=args.transfer_learning_path,
-                transfer_learning_autoencoder=args.transfer_learning_autoencoder,
                 transfer_learning_selection=args.transfer_learning_selection,
                 patch_size=args.patch_size,
                 stride_size=args.stride_size,
@@ -360,7 +357,6 @@ def train_func(args):
                 evaluation_steps=args.evaluation_steps,
                 num_workers=args.nproc,
                 transfer_learning_path=args.transfer_learning_path,
-                transfer_learning_autoencoder=args.transfer_learning_autoencoder,
                 transfer_learning_selection=args.transfer_learning_selection,
                 hippocampus_roi=True,
                 selection_threshold=args.selection_threshold,
@@ -756,11 +752,6 @@ def parse_command_line():
         '--transfer_learning_path',
         help="If an existing path is given, a pretrained model is used.",
         type=str, default=None)
-    transfer_learning_group.add_argument(
-        '--transfer_learning_autoencoder',
-        help='''If specified, do transfer learning using an autoencoder else will look
-                 for a CNN model.''',
-        default=False, action="store_true")
 
     # Autoencoder
     autoencoder_parent = argparse.ArgumentParser(add_help=False)
@@ -935,7 +926,7 @@ def parse_command_line():
     train_roi_cnn_parser._action_groups[-1].add_argument(
         '--transfer_learning_selection',
         help="If transfer_learning from CNN, chooses which best transfer model is selected.",
-        type=str, default="best_acc", choices=["best_loss", "best_acc"])
+        type=str, default="best_balanced_accuracy", choices=["best_loss", "best_balanced_accuracy"])
 
     train_roi_cnn_group = train_roi_cnn_parser.add_argument_group(
         TRAIN_CATEGORIES["ROI CNN"])

--- a/clinicadl/clinicadl/main.py
+++ b/clinicadl/clinicadl/main.py
@@ -23,8 +23,8 @@ def main():
             and (arguments['task'] != 'extract') \
             and (arguments['task'] != 'generate') \
             and (arguments['task'] != 'tsvtool'):
-        commandline_to_json(commandline, arguments["mode_task"])
-        text_file = open(path.join(args.output_dir, 'python_version.txt'), 'w')
+        commandline_to_json(commandline)
+        text_file = open(path.join(args.output_dir, 'environment.txt'), 'w')
         text_file.write('Version of python: %s \n' % sys.version)
         text_file.write('Version of pytorch: %s \n' % torch.__version__)
         text_file.close()

--- a/clinicadl/clinicadl/main.py
+++ b/clinicadl/clinicadl/main.py
@@ -24,7 +24,7 @@ def main():
             and (arguments['task'] != 'generate') \
             and (arguments['task'] != 'tsvtool') \
             and (arguments['task'] != 'classify'):
-        commandline_to_json(commandline, arguments["mode_task"])
+        commandline_to_json(commandline)
         text_file = open(path.join(args.output_dir, 'python_version.txt'), 'w')
         text_file.write('Version of python: %s \n' % sys.version)
         text_file.write('Version of pytorch: %s \n' % torch.__version__)

--- a/clinicadl/clinicadl/test/evaluation_multiCNN.py
+++ b/clinicadl/clinicadl/test/evaluation_multiCNN.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
     # Read json
     model_options = argparse.Namespace()
     json_path = path.join(options.model_path, "commandline_cnn.json")
-    model_options = read_json(model_options, "cnn", json_path=json_path)
+    model_options = read_json(model_options, json_path=json_path)
 
     transformations = get_transforms(model_options.mode, model_options.minmaxnormalization)
     criterion = nn.CrossEntropyLoss()

--- a/clinicadl/clinicadl/test/evaluation_singleCNN.py
+++ b/clinicadl/clinicadl/test/evaluation_singleCNN.py
@@ -34,7 +34,7 @@ if __name__ == "__main__":
     # Read json
     model_options = argparse.Namespace()
     json_path = path.join(options.model_path, "commandline_cnn.json")
-    model_options = read_json(model_options, "cnn", json_path=json_path)
+    model_options = read_json(model_options, json_path=json_path)
 
     transformations = get_transforms(model_options.mode, model_options.minmaxnormalization)
     criterion = nn.CrossEntropyLoss()

--- a/clinicadl/clinicadl/test/test_multiCNN.py
+++ b/clinicadl/clinicadl/test/test_multiCNN.py
@@ -59,7 +59,7 @@ def main(options):
     # Read json
     model_options = argparse.Namespace()
     json_path = path.join(options.model_path, "commandline_cnn.json")
-    model_options = read_json(model_options, "cnn", json_path=json_path)
+    model_options = read_json(model_options, json_path=json_path)
 
     # Load test data
     if options.diagnoses is None:

--- a/clinicadl/clinicadl/test/test_multiCNN.py
+++ b/clinicadl/clinicadl/test/test_multiCNN.py
@@ -15,10 +15,10 @@ from clinicadl.tools.deep_learning.cnn_utils import test, mode_level_to_tsvs, so
 
 
 def test_cnn(output_dir, data_loader, subset_name, split, criterion, cnn_index, model_options, gpu=False):
-    for selection in ["best_acc", "best_loss"]:
+    for selection in ["best_balanced_accuracy", "best_loss"]:
         # load the best trained model during the training
         model = create_model(model_options.model, gpu, dropout=model_options.dropout)
-        model, best_epoch = load_model(model, os.path.join(output_dir, 'best_model_dir', "fold_%i" % split,
+        model, best_epoch = load_model(model, os.path.join(output_dir, 'fold-%i' % split, 'models',
                                                            'cnn-%i' % cnn_index, selection),
                                        gpu=gpu, filename='model_best.pth.tar')
 

--- a/clinicadl/clinicadl/test/test_singleCNN.py
+++ b/clinicadl/clinicadl/test/test_singleCNN.py
@@ -14,11 +14,10 @@ from clinicadl.tools.deep_learning.cnn_utils import test, mode_level_to_tsvs, so
 
 def test_cnn(output_dir, data_loader, subset_name, split, criterion, model_options, gpu=False):
 
-    for selection in ["best_acc", "best_loss"]:
+    for selection in ["best_balanced_accuracy", "best_loss"]:
         # load the best trained model during the training
         model = create_model(model_options.model, gpu, dropout=model_options.dropout)
-        model, best_epoch = load_model(model, os.path.join(output_dir, 'best_model_dir', "fold_%i" % split,
-                                                           'CNN', selection),
+        model, best_epoch = load_model(model, os.path.join(output_dir, 'fold-%i' % split, 'models', selection),
                                        gpu=gpu, filename='model_best.pth.tar')
 
         results_df, metrics = test(model, data_loader, gpu, criterion, model_options.mode)

--- a/clinicadl/clinicadl/test/test_singleCNN.py
+++ b/clinicadl/clinicadl/test/test_singleCNN.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
     # Read json
     model_options = argparse.Namespace()
     json_path = path.join(options.model_path, "commandline_cnn.json")
-    model_options = read_json(model_options, "cnn", json_path=json_path)
+    model_options = read_json(model_options, json_path=json_path)
 
     # Load test data
     if options.diagnoses is None:

--- a/clinicadl/clinicadl/tools/deep_learning/cnn_utils.py
+++ b/clinicadl/clinicadl/tools/deep_learning/cnn_utils.py
@@ -305,9 +305,9 @@ def mode_level_to_tsvs(output_dir, results_df, results, fold, selection, mode, d
         cnn_index: (int) provide the cnn_index only for a multi-cnn framework.
     """
     if cnn_index is None:
-        performance_dir = os.path.join(output_dir, 'performances', 'fold_' + str(fold), selection)
+        performance_dir = os.path.join(output_dir, 'fold-%i' % fold, 'cnn_classification', selection)
     else:
-        performance_dir = os.path.join(output_dir, 'performances', 'fold_' + str(fold), 'cnn-' + str(cnn_index),
+        performance_dir = os.path.join(output_dir, 'fold-%i' % fold, 'cnn_classification', 'cnn-' + str(cnn_index),
                                        selection)
 
     if not os.path.exists(performance_dir):
@@ -323,14 +323,14 @@ def mode_level_to_tsvs(output_dir, results_df, results, fold, selection, mode, d
 def retrieve_sub_level_results(output_dir, fold, selection, mode, dataset, num_cnn):
     """Retrieve performance_df for single or multi-CNN framework."""
     if num_cnn is None:
-        result_tsv = os.path.join(output_dir, 'performances', 'fold_%i' % fold, selection,
+        result_tsv = os.path.join(output_dir, 'fold-%i' % fold, 'cnn_classification', selection,
                                   dataset + '_%s_level_result.tsv' % mode)
         performance_df = pd.read_csv(result_tsv, sep='\t')
 
     else:
         performance_df = pd.DataFrame()
         for cnn in range(num_cnn):
-            tsv_path = os.path.join(output_dir, 'performances', 'fold_%i' % fold, 'cnn-%i' % cnn, selection,
+            tsv_path = os.path.join(output_dir, 'fold-%i' % fold, 'cnn_classification', 'cnn-%i' % cnn, selection,
                                     dataset + '_%s_level_result.tsv' % mode)
             cnn_df = pd.read_csv(tsv_path, sep='\t')
             performance_df = pd.concat([performance_df, cnn_df])
@@ -363,7 +363,7 @@ def soft_voting_to_tsvs(output_dir, fold, selection, mode, dataset='test', num_c
     test_df = retrieve_sub_level_results(output_dir, fold, selection, mode, dataset, num_cnn)
     validation_df = retrieve_sub_level_results(output_dir, fold, selection, mode, validation_dataset, num_cnn)
 
-    performance_path = os.path.join(output_dir, 'performances', 'fold_%i' % fold, selection)
+    performance_path = os.path.join(output_dir, 'fold-%i' % fold, 'cnn_classification', selection)
     if not os.path.exists(performance_path):
         os.makedirs(performance_path)
 
@@ -372,8 +372,7 @@ def soft_voting_to_tsvs(output_dir, fold, selection, mode, dataset='test', num_c
     df_final.to_csv(os.path.join(os.path.join(performance_path, dataset + '_image_level_result.tsv')),
                     index=False, sep='\t')
 
-    pd.DataFrame(metrics, index=[0]).to_csv(os.path.join(output_dir, 'performances', 'fold_%i' % fold, selection,
-                                                         dataset + '_image_level_metrics.tsv'),
+    pd.DataFrame(metrics, index=[0]).to_csv(os.path.join(performance_path, dataset + '_image_level_metrics.tsv'),
                                             index=False, sep='\t')
 
 

--- a/clinicadl/clinicadl/tools/deep_learning/cnn_utils.py
+++ b/clinicadl/clinicadl/tools/deep_learning/cnn_utils.py
@@ -313,7 +313,7 @@ def mode_level_to_tsvs(output_dir, results_df, results, fold, selection, mode, d
     if not os.path.exists(performance_dir):
         os.makedirs(performance_dir)
 
-    results_df.to_csv(os.path.join(performance_dir, '%s_%s_level_result.tsv' % (dataset, mode)), index=False,
+    results_df.to_csv(os.path.join(performance_dir, '%s_%s_level_prediction.tsv' % (dataset, mode)), index=False,
                       sep='\t')
 
     pd.DataFrame(results, index=[0]).to_csv(os.path.join(performance_dir, '%s_%s_level_metrics.tsv' % (dataset, mode)),
@@ -324,14 +324,14 @@ def retrieve_sub_level_results(output_dir, fold, selection, mode, dataset, num_c
     """Retrieve performance_df for single or multi-CNN framework."""
     if num_cnn is None:
         result_tsv = os.path.join(output_dir, 'fold-%i' % fold, 'cnn_classification', selection,
-                                  dataset + '_%s_level_result.tsv' % mode)
+                                  dataset + '_%s_level_prediction.tsv' % mode)
         performance_df = pd.read_csv(result_tsv, sep='\t')
 
     else:
         performance_df = pd.DataFrame()
         for cnn in range(num_cnn):
             tsv_path = os.path.join(output_dir, 'fold-%i' % fold, 'cnn_classification', 'cnn-%i' % cnn, selection,
-                                    dataset + '_%s_level_result.tsv' % mode)
+                                    dataset + '_%s_level_prediction.tsv' % mode)
             cnn_df = pd.read_csv(tsv_path, sep='\t')
             performance_df = pd.concat([performance_df, cnn_df])
         performance_df.reset_index(drop=True, inplace=True)
@@ -369,7 +369,7 @@ def soft_voting_to_tsvs(output_dir, fold, selection, mode, dataset='test', num_c
 
     df_final, metrics = soft_voting(test_df, validation_df, mode, selection_threshold=selection_threshold)
 
-    df_final.to_csv(os.path.join(os.path.join(performance_path, dataset + '_image_level_result.tsv')),
+    df_final.to_csv(os.path.join(os.path.join(performance_path, dataset + '_image_level_prediction.tsv')),
                     index=False, sep='\t')
 
     pd.DataFrame(metrics, index=[0]).to_csv(os.path.join(performance_path, dataset + '_image_level_metrics.tsv'),

--- a/clinicadl/clinicadl/tools/deep_learning/iotools.py
+++ b/clinicadl/clinicadl/tools/deep_learning/iotools.py
@@ -56,8 +56,8 @@ class Parameters:
             mri_plane: int = 0,
             discarded_slices: int = 20,
             prepare_dl: bool = False,
-            visualization: bool = False,
-            init_state: str = None):
+            visualization: bool = False
+    ):
         """
         Optional parameters used for training CNN.
         transfer_learning_difference: Difference of size between the pretrained
@@ -130,16 +130,6 @@ class Parameters:
         self.prepare_dl = prepare_dl
         self.visualization = visualization
         self.selection_threshold = selection_threshold
-        self.init_state = init_state
-        self.set_default_init_state()
-
-    def set_default_init_state(self):
-        """Sets init state according to experiments performed in AD-DL"""
-        if self.init_state is None:
-            if self.mode in ["patch", "roi"]:
-                self.init_state = "same"
-            else:
-                self.init_state = "random"
 
 
 def check_and_clean(d):

--- a/clinicadl/clinicadl/tools/deep_learning/iotools.py
+++ b/clinicadl/clinicadl/tools/deep_learning/iotools.py
@@ -46,7 +46,6 @@ class Parameters:
             evaluation_steps: int = 0,
             num_workers: int = 1,
             transfer_learning_path: str = None,
-            transfer_learning_autoencoder: str = None,
             transfer_learning_selection: str = "best_acc",
             patch_size: int = 50,
             stride_size: int = 50,
@@ -119,7 +118,6 @@ class Parameters:
         self.evaluation_steps = evaluation_steps
         self.num_workers = num_workers
         self.transfer_learning_path = transfer_learning_path
-        self.transfer_learning_autoencoder = transfer_learning_autoencoder
         self.transfer_learning_selection = transfer_learning_selection
         self.patch_size = patch_size
         self.stride_size = stride_size

--- a/clinicadl/clinicadl/tools/deep_learning/iotools.py
+++ b/clinicadl/clinicadl/tools/deep_learning/iotools.py
@@ -151,14 +151,13 @@ def check_and_clean(d):
     os.makedirs(d)
 
 
-def commandline_to_json(commandline, task_type):
+def commandline_to_json(commandline):
     """
     This is a function to write the python argparse object into a json file.
     This helps for DL when searching for hyperparameters
 
     :param commandline: a tuple contain the output of
                         `parser.parse_known_args()`
-    :param task_type: task type (autoencoder, cnn)                   
 
     :return:
     """
@@ -187,8 +186,8 @@ def commandline_to_json(commandline, task_type):
 
     # save to json file
     json = json.dumps(commandline_arg_dic, skipkeys=True)
-    print("Path of json file:", os.path.join(output_dir, "commandline_" + task_type + ".json"))
-    f = open(os.path.join(output_dir, "commandline_" + task_type + ".json"), "w")
+    print("Path of json file:", os.path.join(output_dir, "commandline.json"))
+    f = open(os.path.join(output_dir, "commandline.json"), "w")
     f.write(json)
     f.close()
 

--- a/clinicadl/clinicadl/tools/deep_learning/iotools.py
+++ b/clinicadl/clinicadl/tools/deep_learning/iotools.py
@@ -182,12 +182,16 @@ def commandline_to_json(commandline):
     f.close()
 
 
-def read_json(options, task_type, json_path=None, test=False):
+def read_json(options, json_path=None, test=False):
     """
     Read a json file to update python argparse Namespace.
 
-    :param options: (argparse.Namespace) options of the model
-    :return: options (args.Namespace) options of the model updated
+    Args:
+        options: (argparse.Namespace) options of the model.
+        json_path: (str) If given path to the json file, else found with options.model_path.
+        test: (bool) If given the reader will ignore some options specific to data.
+    Returns:
+        options (args.Namespace) options of the model updated
     """
     import json
     from os import path
@@ -196,7 +200,7 @@ def read_json(options, task_type, json_path=None, test=False):
     evaluation_parameters = ["diagnosis_path", "input_dir", "diagnoses"]
     prep_compatibility_dict = {"mni": "t1-extensive", "linear": "t1-linear"}
     if json_path is None:
-        json_path = path.join(options.model_path, 'commandline_' + task_type + '.json')
+        json_path = path.join(options.model_path, 'commandline.json')
 
     with open(json_path, "r") as f:
         json_data = json.load(f)

--- a/clinicadl/clinicadl/tools/deep_learning/models/__init__.py
+++ b/clinicadl/clinicadl/tools/deep_learning/models/__init__.py
@@ -11,7 +11,6 @@ def create_model(model_name, gpu=False, **kwargs):
 
     :param model_name: (str) the name of the model (corresponding exactly to the name of the class).
     :param gpu: (bool) if True a gpu is used.
-    :param init_state: (str) If 'same' will load
     :return: (Module) the model object
     """
 
@@ -53,35 +52,10 @@ def create_autoencoder(model_name, gpu=False, transfer_learning_path=None, diffe
     return decoder
 
 
-def save_initialization(model_name, init_dir, init_state="random", autoencoder=False, **kwargs):
-    """
-    Saves the parameters initialization of a random model created from options and initial_shape.
-
-    :param model_name: (str) the name of the model (corresponding exactly to the name of the class).
-    :param init_dir: (str) path to the parent directory containing initialization state of the model.
-    :param init_state: (str) If 'same' a state will be saved to be loaded at each training.
-    :return: None
-    """
-    from os import path
-
-    if init_state == 'same' and not path.exists(path.join(init_dir, "init.pth.tar")):
-        model = create_model(model_name, **kwargs)
-        if autoencoder:
-            model = AutoEncoder(model)
-        init_dict = {"model": model.state_dict(),
-                     "epoch": -1,
-                     "valid_acc": None,
-                     "valid_loss": None}
-        save_checkpoint(init_dict, False, False, init_dir, filename="init.pth.tar")
-
-
-def init_model(model_name, init_dir, init_state="random", autoencoder=False, gpu=False, **kwargs):
+def init_model(model_name, autoencoder=False, gpu=False, **kwargs):
 
     model = create_model(model_name, gpu=gpu, **kwargs)
     if autoencoder:
         model = AutoEncoder(model)
-
-    if init_state == 'same':
-        model, _ = load_model(model, init_dir, gpu, filename="init.pth.tar")
 
     return model

--- a/clinicadl/clinicadl/tools/deep_learning/models/autoencoder.py
+++ b/clinicadl/clinicadl/tools/deep_learning/models/autoencoder.py
@@ -5,7 +5,6 @@ import torch
 from copy import deepcopy
 
 from .modules import PadMaxPool3d, CropMaxUnpool3d, Flatten, Reshape
-from .iotools import load_model
 
 
 class AutoEncoder(nn.Module):
@@ -121,23 +120,27 @@ class AutoEncoder(nn.Module):
         return inv_layers
 
 
-def transfer_learning(model, split, transfer_learning_autoencoder=True, source_path=None, gpu=False,
+def transfer_learning(model, split, source_path=None, gpu=False,
                       selection="best_balanced_accuracy", cnn_index=None):
     """
     Allows transfer learning from a CNN or an autoencoder to a CNN
 
     :param model: (nn.Module) the target CNN of the transfer learning.
     :param split: (int) the fold number (for serialization purpose).
-    :param transfer_learning_autoencoder: (bool) If True (resp. False), the initialization is from an AE (resp. CNN)
     :param source_path: (str) path to the source experiment.
     :param gpu: (bool) If True a GPU is used.
     :param selection: (str) chooses on which criterion the source model is selected (ex: best_loss, best_acc)
     :param cnn_index: (int) index of the CNN to be loaded (if transfer from a multi-CNN).
     :return: (nn.Module) the model after transfer learning.
     """
+    import argparse
+    from os import path
+    from .. import read_json
 
     if source_path is not None:
-        if transfer_learning_autoencoder:
+        source_commandline = argparse.Namespace()
+        source_commandline = read_json(source_commandline, json_path=path.join(source_path, "commandline.json"))
+        if source_commandline.mode_task == "autoencoder":
             print("A pretrained autoencoder is loaded at path %s" % source_path)
             model = transfer_autoencoder_weights(model, source_path, split)
 

--- a/clinicadl/clinicadl/tools/deep_learning/models/autoencoder.py
+++ b/clinicadl/clinicadl/tools/deep_learning/models/autoencoder.py
@@ -170,8 +170,7 @@ def transfer_autoencoder_weights(model, source_path, split):
     import os
 
     decoder = AutoEncoder(model)
-    model_path = os.path.join(source_path, "best_model_dir", "fold_" + str(split), "ConvAutoencoder",
-                              "best_loss", "model_best.pth.tar")
+    model_path = os.path.join(source_path, 'fold-%i' % split, 'models', "best_loss", "model_best.pth.tar")
 
     initialize_other_autoencoder(decoder, model_path, difference=0)
 
@@ -198,11 +197,10 @@ def transfer_cnn_weights(model, source_path, split, selection="best_acc", cnn_in
     import os
     import torch
 
-    model_path = os.path.join(source_path, "best_model_dir", "fold_%i" % split, "CNN",
-                              selection, "model_best.pth.tar")
+    model_path = os.path.join(source_path, "fold-%i" % split, "models", selection, "model_best.pth.tar")
     if cnn_index is not None and not os.path.exists(model_path):
         print("Transfer learning from multi-CNN, cnn-%i" % cnn_index)
-        model_path = os.path.join(source_path, "best_model_dir", "fold_%i" % split, "cnn-%i" % cnn_index,
+        model_path = os.path.join(source_path, "fold_%i" % split, "models", "cnn-%i" % cnn_index,
                                   selection, "model_best.pth.tar")
     results = torch.load(model_path)
     model.load_state_dict(results['model'])

--- a/clinicadl/clinicadl/tools/deep_learning/models/autoencoder.py
+++ b/clinicadl/clinicadl/tools/deep_learning/models/autoencoder.py
@@ -122,7 +122,7 @@ class AutoEncoder(nn.Module):
 
 
 def transfer_learning(model, split, transfer_learning_autoencoder=True, source_path=None, gpu=False,
-                      selection="best_acc", cnn_index=None):
+                      selection="best_balanced_accuracy", cnn_index=None):
     """
     Allows transfer learning from a CNN or an autoencoder to a CNN
 
@@ -182,7 +182,7 @@ def transfer_autoencoder_weights(model, source_path, split):
     return model
 
 
-def transfer_cnn_weights(model, source_path, split, selection="best_acc", cnn_index=None):
+def transfer_cnn_weights(model, source_path, split, selection="best_balanced_accuracy", cnn_index=None):
     """
     Set the weights of the model according to the CNN at source path.
 

--- a/clinicadl/clinicadl/tools/deep_learning/models/iotools.py
+++ b/clinicadl/clinicadl/tools/deep_learning/models/iotools.py
@@ -6,7 +6,7 @@ Script containing the iotools for model and optimizer serialization.
 
 
 def save_checkpoint(state, accuracy_is_best, loss_is_best, checkpoint_dir, filename='checkpoint.pth.tar',
-                    best_accuracy='best_acc', best_loss='best_loss'):
+                    best_accuracy='best_balanced_accuracy', best_loss='best_loss'):
     import torch
     import os
     import shutil

--- a/clinicadl/clinicadl/train/resume_CNN.py
+++ b/clinicadl/clinicadl/train/resume_CNN.py
@@ -28,7 +28,7 @@ parser.add_argument("--num_workers", '-w', default=1, type=int,
 
 def main(options):
 
-    options = read_json(options, "CNN")
+    options = read_json(options)
 
     if options.evaluation_steps % options.accumulation_steps != 0 and options.evaluation_steps != 1:
         raise Exception('Evaluation steps %d must be a multiple of accumulation steps %d' %

--- a/clinicadl/clinicadl/train/resume_autoencoder.py
+++ b/clinicadl/clinicadl/train/resume_autoencoder.py
@@ -27,7 +27,7 @@ parser.add_argument("--num_workers", '-w', default=1, type=int,
 
 def main(options):
 
-    options = read_json(options, "ConvAutoencoder")
+    options = read_json(options)
 
     if options.evaluation_steps % options.accumulation_steps != 0 and options.evaluation_steps != 1:
         raise Exception('Evaluation steps %d must be a multiple of accumulation steps %d' %

--- a/clinicadl/clinicadl/train/train_autoencoder.py
+++ b/clinicadl/clinicadl/train/train_autoencoder.py
@@ -68,6 +68,7 @@ def train_autoencoder(params):
         log_dir = os.path.join(params.output_dir, 'fold-%i' % fi, 'tensorboard_logs')
         model_dir = os.path.join(params.output_dir, 'fold-%i' % fi, 'models')
         visualization_dir = os.path.join(params.output_dir, 'fold-%i' % fi, 'autoencoder_reconstruction')
+        print(model_dir)
 
         decoder = init_model(params.model, gpu=params.gpu, autoencoder=True, dropout=params.dropout)
         optimizer = eval("torch.optim." + params.optimizer)(filter(lambda x: x.requires_grad, decoder.parameters()),

--- a/clinicadl/clinicadl/train/train_autoencoder.py
+++ b/clinicadl/clinicadl/train/train_autoencoder.py
@@ -5,7 +5,7 @@ import os
 from torch.utils.data import DataLoader
 
 from ..tools.deep_learning.autoencoder_utils import train, visualize_image
-from ..tools.deep_learning.models import init_model, load_model, save_initialization
+from ..tools.deep_learning.models import init_model, load_model
 from ..tools.deep_learning.data import (load_data,
                                         get_transforms,
                                         return_dataset)
@@ -24,8 +24,6 @@ def train_autoencoder(params):
     of the last epoch that was completed before the crash.
     """
 
-    init_path = os.path.join(params.output_dir, 'best_model_dir', 'ConvAutoencoder')
-    save_initialization(params.model, init_path, init_state=params.init_state, autoencoder=True, dropout=params.dropout)
     transformations = get_transforms(params.mode, params.minmaxnormalization)
     criterion = torch.nn.MSELoss()
 
@@ -71,8 +69,7 @@ def train_autoencoder(params):
         model_dir = os.path.join(params.output_dir, 'fold-%i' % fi, 'models')
         visualization_dir = os.path.join(params.output_dir, 'fold-%i' % fi, 'autoencoder_reconstruction')
 
-        decoder = init_model(params.model, init_path, params.init_state, gpu=params.gpu,
-                             autoencoder=True, dropout=params.dropout)
+        decoder = init_model(params.model, gpu=params.gpu, autoencoder=True, dropout=params.dropout)
         optimizer = eval("torch.optim." + params.optimizer)(filter(lambda x: x.requires_grad, decoder.parameters()),
                                                             lr=params.learning_rate,
                                                             weight_decay=params.weight_decay)

--- a/clinicadl/clinicadl/train/train_autoencoder.py
+++ b/clinicadl/clinicadl/train/train_autoencoder.py
@@ -68,7 +68,6 @@ def train_autoencoder(params):
         log_dir = os.path.join(params.output_dir, 'fold-%i' % fi, 'tensorboard_logs')
         model_dir = os.path.join(params.output_dir, 'fold-%i' % fi, 'models')
         visualization_dir = os.path.join(params.output_dir, 'fold-%i' % fi, 'autoencoder_reconstruction')
-        print(model_dir)
 
         decoder = init_model(params.model, gpu=params.gpu, autoencoder=True, dropout=params.dropout)
         optimizer = eval("torch.optim." + params.optimizer)(filter(lambda x: x.requires_grad, decoder.parameters()),

--- a/clinicadl/clinicadl/train/train_autoencoder.py
+++ b/clinicadl/clinicadl/train/train_autoencoder.py
@@ -67,9 +67,9 @@ def train_autoencoder(params):
                 pin_memory=True)
 
         # Define output directories
-        log_dir = os.path.join(params.output_dir, "log_dir", "fold_%i" % fi, "ConvAutoencoder")
-        model_dir = os.path.join(params.output_dir, "best_model_dir", "fold_%i" % fi, "ConvAutoencoder")
-        visualization_dir = os.path.join(params.output_dir, 'autoencoder_reconstruction', 'fold_%i' % fi)
+        log_dir = os.path.join(params.output_dir, 'fold-%i' % fi, 'tensorboard_logs')
+        model_dir = os.path.join(params.output_dir, 'fold-%i' % fi, 'models')
+        visualization_dir = os.path.join(params.output_dir, 'fold-%i' % fi, 'autoencoder_reconstruction')
 
         decoder = init_model(params.model, init_path, params.init_state, gpu=params.gpu,
                              autoencoder=True, dropout=params.dropout)

--- a/clinicadl/clinicadl/train/train_multiCNN.py
+++ b/clinicadl/clinicadl/train/train_multiCNN.py
@@ -4,7 +4,7 @@ import os
 import torch
 from torch.utils.data import DataLoader
 
-from ..tools.deep_learning.models import transfer_learning, save_initialization, init_model
+from ..tools.deep_learning.models import transfer_learning, init_model
 from ..tools.deep_learning.data import (get_transforms,
                                         load_data,
                                         return_dataset)
@@ -26,8 +26,6 @@ def train_multi_cnn(params):
     of the last epoch that was completed before the crash.
     """
 
-    init_path = os.path.join(params.output_dir, 'best_model_dir', 'CNN')
-    save_initialization(params.model, init_path, init_state=params.init_state, dropout=params.dropout)
     transformations = get_transforms(params.mode, params.minmaxnormalization)
 
     if params.split is None:
@@ -70,7 +68,7 @@ def train_multi_cnn(params):
 
             # Initialize the model
             print('Initialization of the model')
-            model = init_model(params.model, init_path, params.init_state, gpu=params.gpu, dropout=params.dropout)
+            model = init_model(params.model, gpu=params.gpu, dropout=params.dropout)
             model = transfer_learning(model, fi, source_path=params.transfer_learning_path,
                                       transfer_learning_autoencoder=params.transfer_learning_autoencoder,
                                       gpu=params.gpu, selection=params.transfer_learning_selection)

--- a/clinicadl/clinicadl/train/train_multiCNN.py
+++ b/clinicadl/clinicadl/train/train_multiCNN.py
@@ -83,8 +83,8 @@ def train_multi_cnn(params):
             setattr(params, 'beginning_epoch', 0)
 
             # Define output directories
-            log_dir = os.path.join(params.output_dir, "log_dir", "fold_%i" % fi, "cnn-%i" % cnn_index,)
-            model_dir = os.path.join(params.output_dir, "best_model_dir", "fold_%i" % fi, "cnn-%i" % cnn_index)
+            log_dir = os.path.join(params.output_dir, 'fold-%i' % fi, 'tensorboard_logs', "cnn-%i" % cnn_index,)
+            model_dir = os.path.join(params.output_dir, 'fold-%i' % fi, 'models', "cnn-%i" % cnn_index)
 
             print('Beginning the training task')
             train(model, train_loader, valid_loader, criterion, optimizer, False, log_dir, model_dir, params)
@@ -92,7 +92,7 @@ def train_multi_cnn(params):
             test_cnn(params.output_dir, train_loader, "train", fi, criterion, cnn_index, params, gpu=params.gpu)
             test_cnn(params.output_dir, valid_loader, "validation", fi, criterion, cnn_index, params, gpu=params.gpu)
 
-        for selection in ['best_acc', 'best_loss']:
+        for selection in ['best_balanced_accuracy', 'best_loss']:
             soft_voting_to_tsvs(
                 params.output_dir,
                 fi,

--- a/clinicadl/clinicadl/train/train_multiCNN.py
+++ b/clinicadl/clinicadl/train/train_multiCNN.py
@@ -70,7 +70,6 @@ def train_multi_cnn(params):
             print('Initialization of the model')
             model = init_model(params.model, gpu=params.gpu, dropout=params.dropout)
             model = transfer_learning(model, fi, source_path=params.transfer_learning_path,
-                                      transfer_learning_autoencoder=params.transfer_learning_autoencoder,
                                       gpu=params.gpu, selection=params.transfer_learning_selection)
 
             # Define criterion and optimizer

--- a/clinicadl/clinicadl/train/train_singleCNN.py
+++ b/clinicadl/clinicadl/train/train_singleCNN.py
@@ -83,9 +83,9 @@ def train_single_cnn(params):
 
         # Define output directories
         log_dir = os.path.join(
-            params.output_dir, 'log_dir', 'fold_%i' % fi, 'CNN')
+            params.output_dir, 'fold-%i' % fi, 'tensorboard_logs')
         model_dir = os.path.join(
-            params.output_dir, 'best_model_dir', 'fold_%i' % fi, 'CNN')
+            params.output_dir, 'fold-%i' % fi, 'models')
 
         print('Beginning the training task')
         train(model, train_loader, valid_loader, criterion,

--- a/clinicadl/clinicadl/train/train_singleCNN.py
+++ b/clinicadl/clinicadl/train/train_singleCNN.py
@@ -4,7 +4,7 @@ import os
 import torch
 from torch.utils.data import DataLoader
 
-from ..tools.deep_learning.models import transfer_learning, save_initialization, init_model
+from ..tools.deep_learning.models import transfer_learning, init_model
 from ..tools.deep_learning.data import (get_transforms,
                                         load_data,
                                         return_dataset)

--- a/clinicadl/clinicadl/train/train_singleCNN.py
+++ b/clinicadl/clinicadl/train/train_singleCNN.py
@@ -67,7 +67,6 @@ def train_single_cnn(params):
         print('Initialization of the model')
         model = init_model(params.model, gpu=params.gpu, dropout=params.dropout)
         model = transfer_learning(model, fi, source_path=params.transfer_learning_path,
-                                  transfer_learning_autoencoder=params.transfer_learning_autoencoder,
                                   gpu=params.gpu, selection=params.transfer_learning_selection)
 
         # Define criterion and optimizer

--- a/clinicadl/clinicadl/train/train_singleCNN.py
+++ b/clinicadl/clinicadl/train/train_singleCNN.py
@@ -25,9 +25,6 @@ def train_single_cnn(params):
     of the last epoch that was completed before the crash.
     """
 
-    init_path = os.path.join(params.output_dir, 'best_model_dir', 'CNN')
-    save_initialization(params.model, init_path,
-                        init_state=params.init_state, dropout=params.dropout)
     transformations = get_transforms(params.mode, params.minmaxnormalization)
 
     if params.split is None:
@@ -68,8 +65,7 @@ def train_single_cnn(params):
 
         # Initialize the model
         print('Initialization of the model')
-        model = init_model(params.model, init_path, params.init_state,
-                           gpu=params.gpu, dropout=params.dropout)
+        model = init_model(params.model, gpu=params.gpu, dropout=params.dropout)
         model = transfer_learning(model, fi, source_path=params.transfer_learning_path,
                                   transfer_learning_autoencoder=params.transfer_learning_autoencoder,
                                   gpu=params.gpu, selection=params.transfer_learning_selection)

--- a/clinicadl/clinicadl/train/train_singleCNN_bad_data_split.py
+++ b/clinicadl/clinicadl/train/train_singleCNN_bad_data_split.py
@@ -268,8 +268,8 @@ def train_CNN_bad_data_split(params):
         setattr(params, 'beginning_epoch', 0)
 
         # Define output directories
-        log_dir = os.path.join(params.output_dir, "log_dir", "fold_%i" % fi, "CNN")
-        model_dir = os.path.join(params.output_dir, "best_model_dir", "fold_%i" % fi, "CNN")
+        log_dir = os.path.join(params.output_dir, 'fold-%i' % fi, 'tensorboard_logs')
+        model_dir = os.path.join(params.output_dir, 'fold-%i' % fi, 'models')
 
         print('Beginning the training task')
         train(model, train_loader, valid_loader, criterion, optimizer, False, log_dir, model_dir, params)

--- a/clinicadl/clinicadl/train/train_singleCNN_bad_data_split.py
+++ b/clinicadl/clinicadl/train/train_singleCNN_bad_data_split.py
@@ -30,150 +30,163 @@ def test_cnn(data_loader, subset_name, split, criterion, options):
 
     for selection in ["best_acc", "best_loss"]:
         # load the best trained model during the training
-        model = init_model(options.model, gpu=options.gpu, dropout=options.dropout)
+        model = init_model(
+            options.model,
+            gpu=options.gpu,
+            dropout=options.dropout)
         model, best_epoch = load_model(model, os.path.join(options.output_dir, 'best_model_dir', "fold_%i" % split,
                                                            'CNN', selection),
                                        gpu=options.gpu, filename='model_best.pth.tar')
 
-        results_df, metrics = test(model, data_loader, options.gpu, criterion, options.mode)
-        print("Slice level balanced accuracy is %f" % metrics['balanced_accuracy'])
+        results_df, metrics = test(
+            model, data_loader, options.gpu, criterion, options.mode)
+        print(
+            "Slice level balanced accuracy is %f" %
+            metrics['balanced_accuracy'])
 
-        mode_level_to_tsvs(options.output_dir, results_df, metrics, split, selection, options.mode, dataset=subset_name)
+        mode_level_to_tsvs(
+            options.output_dir,
+            results_df,
+            metrics,
+            split,
+            selection,
+            options.mode,
+            dataset=subset_name)
 
 
 # Train 2D CNN - Slice level network
 # The input MRI's dimension is 169*208*179 after cropping"
 parser = argparse.ArgumentParser(
-        description="Argparser for Pytorch 2D CNN, The input MRI's dimension is 169*208*179 after cropping")
+    description="Argparser for Pytorch 2D CNN, The input MRI's dimension is 169*208*179 after cropping")
 
 # Mandatory argument
 parser.add_argument(
-        "caps_directory",
-        type=str,
-        help="Path to the caps of image processing pipeline of DL")
+    "caps_directory",
+    type=str,
+    help="Path to the caps of image processing pipeline of DL")
 
 parser.add_argument(
-        "tsv_path",
-        type=str,
-        help="Path to tsv file of the population based on the diagnosis tsv files. "
-             "To note, the column name should be participant_id, session_id and diagnosis.")
+    "tsv_path",
+    type=str,
+    help="Path to tsv file of the population based on the diagnosis tsv files. "
+    "To note, the column name should be participant_id, session_id and diagnosis.")
 parser.add_argument(
-        "output_dir",
-        type=str,
-        help="Path to store the classification outputs, and the tsv files containing the performances.")
+    "output_dir",
+    type=str,
+    help="Path to store the classification outputs, and the tsv files containing the performances.")
 
 # Data argument
 parser.add_argument(
-        "--mri_plane",
-        default=0,
-        type=int,
-        help='Which coordinate axis to take for slicing the MRI. 0 is for saggital, 1 is for coronal and 2 is for axial direction, respectively ')
+    "--mri_plane",
+    default=0,
+    type=int,
+    help='Which coordinate axis to take for slicing the MRI. 0 is for saggital, 1 is for coronal and 2 is for axial direction, respectively ')
 
 parser.add_argument(
-        '--baseline',
-        default=False,
-        action="store_true",
-        help="Using baseline scans or all available longitudinal scans for training")
+    '--baseline',
+    default=False,
+    action="store_true",
+    help="Using baseline scans or all available longitudinal scans for training")
 
 # train argument
 parser.add_argument(
-        "--model",
-        default="resnet18",
-        help="Deep network type. Only ResNet was designed for training from scratch.")
+    "--model",
+    default="resnet18",
+    help="Deep network type. Only ResNet was designed for training from scratch.")
 
 parser.add_argument(
-        "--diagnoses",
-        default=["AD", "CN"],
-        type=str,
-        nargs="+",
-        help="Labels for any binary task")
+    "--diagnoses",
+    default=["AD", "CN"],
+    type=str,
+    nargs="+",
+    help="Labels for any binary task")
 
 parser.add_argument(
-        "--learning_rate", "-lr",
-        default=1e-3,
-        type=float,
-        help="Learning rate of the optimization. (default=0.01)")
+    "--learning_rate", "-lr",
+    default=1e-3,
+    type=float,
+    help="Learning rate of the optimization. (default=0.01)")
 
 parser.add_argument(
-        "--n_splits",
-        default=5,
-        type=int,
-        help="Define the cross validation, by default, we use 5-fold.")
+    "--n_splits",
+    default=5,
+    type=int,
+    help="Define the cross validation, by default, we use 5-fold.")
 
 parser.add_argument(
-        "--split",
-        default=None,
-        type=int,
-        help="Define a specific fold in the k-fold, this is very useful to find the optimal model, where you do not want to run your k-fold validation")
+    "--split",
+    default=None,
+    type=int,
+    help="Define a specific fold in the k-fold, this is very useful to find the optimal model, where you do not want to run your k-fold validation")
 
 parser.add_argument(
-        "--epochs",
-        default=1,
-        type=int,
-        help="Epochs through the data. (default=20)")
+    "--epochs",
+    default=1,
+    type=int,
+    help="Epochs through the data. (default=20)")
 
 parser.add_argument(
-        "--batch_size",
-        default=32,
-        type=int,
-        help="Batch size for training. (default=1)")
+    "--batch_size",
+    default=32,
+    type=int,
+    help="Batch size for training. (default=1)")
 
 parser.add_argument(
-        "--optimizer",
-        default="Adam",
-        choices=["SGD", "Adadelta", "Adam"],
-        help="Optimizer of choice for training. (default=Adam)")
+    "--optimizer",
+    default="Adam",
+    choices=["SGD", "Adadelta", "Adam"],
+    help="Optimizer of choice for training. (default=Adam)")
 
 parser.add_argument(
-        "--gpu",
-        default=False,
-        action="store_true",
-        help="If use gpu or cpu. Empty implies cpu usage.")
+    "--gpu",
+    default=False,
+    action="store_true",
+    help="If use gpu or cpu. Empty implies cpu usage.")
 
 parser.add_argument(
-        "--num_workers",
-        default=0,
-        type=int,
-        help='the number of batch being loaded in parallel')
+    "--num_workers",
+    default=0,
+    type=int,
+    help='the number of batch being loaded in parallel')
 
 parser.add_argument(
-        "--weight_decay",
-        default=1e-2,
-        type=float,
-        help='weight decay (default: 1e-4)')
+    "--weight_decay",
+    default=1e-2,
+    type=float,
+    help='weight decay (default: 1e-4)')
 
 parser.add_argument(
-        "--dropout",
-        default=0,
-        type=float,
-        help="Rate of dropout applied to dropout layers."
+    "--dropout",
+    default=0,
+    type=float,
+    help="Rate of dropout applied to dropout layers."
 )
 
 parser.add_argument(
-        '--selection_threshold',
-        default=None,
-        type=float,
-        help='Threshold on the balanced accuracies to compute the subject-level '
-             'performance only based on patches with balanced accuracy > threshold.')
+    '--selection_threshold',
+    default=None,
+    type=float,
+    help='Threshold on the balanced accuracies to compute the subject-level '
+    'performance only based on patches with balanced accuracy > threshold.')
 
 parser.add_argument(
-        '--prepare_dl',
-        default=False,
-        action="store_true",
-        help="If True the outputs of preprocessing prepare_dl are used, else the whole MRI is loaded.")
+    '--prepare_dl',
+    default=False,
+    action="store_true",
+    help="If True the outputs of preprocessing prepare_dl are used, else the whole MRI is loaded.")
 
 # early stopping arguments
 parser.add_argument(
-        "--patience",
-        type=int,
-        default=10,
-        help="tolerated epochs without improving for early stopping.")
+    "--patience",
+    type=int,
+    default=10,
+    help="tolerated epochs without improving for early stopping.")
 
 parser.add_argument(
-        "--tolerance",
-        type=float,
-        default=0,
-        help="Tolerance of magnitude of performance after each epoch.")
+    "--tolerance",
+    type=float,
+    default=0,
+    help="Tolerance of magnitude of performance after each epoch.")
 
 
 def train_CNN_bad_data_split(params):
@@ -182,7 +195,8 @@ def train_CNN_bad_data_split(params):
     print('Do transfer learning with existed model trained on ImageNet!\n')
     print('The chosen network is %s !' % params.model)
 
-    trg_size = (224, 224)  # most of the imagenet pretrained model has this input size
+    # most of the imagenet pretrained model has this input size
+    trg_size = (224, 224)
 
     # All pre-trained models expect input images normalized in the same way,
     # i.e. mini-batches of 3-channel RGB images of shape (3 x H x W), where H
@@ -206,56 +220,59 @@ def train_CNN_bad_data_split(params):
         print("Running for the %d-th fold" % fi)
 
         training_sub_df, valid_sub_df = load_data(
-                params.tsv_path,
-                params.diagnoses,
-                fi,
-                n_splits=params.n_splits,
-                baseline=params.baseline
-                )
+            params.tsv_path,
+            params.diagnoses,
+            fi,
+            n_splits=params.n_splits,
+            baseline=params.baseline
+        )
 
         # split the training + validation by slice
         training_df, valid_df = mix_slices(
-                training_sub_df,
-                valid_sub_df,
-                mri_plane=params.mri_plane
-                )
+            training_sub_df,
+            valid_sub_df,
+            mri_plane=params.mri_plane
+        )
 
         data_train = MRIDataset_slice_mixed(
-                params.caps_directory,
-                training_df,
-                transformations=transformations,
-                mri_plane=params.mri_plane,
-                prepare_dl=params.prepare_dl
-                )
+            params.caps_directory,
+            training_df,
+            transformations=transformations,
+            mri_plane=params.mri_plane,
+            prepare_dl=params.prepare_dl
+        )
 
         data_valid = MRIDataset_slice_mixed(
-                params.caps_directory,
-                valid_df,
-                transformations=transformations,
-                mri_plane=params.mri_plane,
-                prepare_dl=params.prepare_dl
-                )
+            params.caps_directory,
+            valid_df,
+            transformations=transformations,
+            mri_plane=params.mri_plane,
+            prepare_dl=params.prepare_dl
+        )
 
         # Use argument load to distinguish training and testing
         train_loader = DataLoader(
-                data_train,
-                batch_size=params.batch_size,
-                shuffle=True,
-                num_workers=params.num_workers,
-                pin_memory=True
-                )
+            data_train,
+            batch_size=params.batch_size,
+            shuffle=True,
+            num_workers=params.num_workers,
+            pin_memory=True
+        )
 
         valid_loader = DataLoader(
-                data_valid,
-                batch_size=params.batch_size,
-                shuffle=False,
-                num_workers=params.num_workers,
-                pin_memory=True
-                )
+            data_valid,
+            batch_size=params.batch_size,
+            shuffle=False,
+            num_workers=params.num_workers,
+            pin_memory=True
+        )
 
         # Initialize the model
         print('Initialization of the model')
-        model = init_model(params.model, gpu=params.gpu, dropout=params.dropout)
+        model = init_model(
+            params.model,
+            gpu=params.gpu,
+            dropout=params.dropout)
 
         # Define criterion and optimizer
         criterion = torch.nn.CrossEntropyLoss()
@@ -265,11 +282,22 @@ def train_CNN_bad_data_split(params):
         setattr(params, 'beginning_epoch', 0)
 
         # Define output directories
-        log_dir = os.path.join(params.output_dir, 'fold-%i' % fi, 'tensorboard_logs')
+        log_dir = os.path.join(
+            params.output_dir, 'fold-%i' %
+            fi, 'tensorboard_logs')
         model_dir = os.path.join(params.output_dir, 'fold-%i' % fi, 'models')
 
         print('Beginning the training task')
-        train(model, train_loader, valid_loader, criterion, optimizer, False, log_dir, model_dir, params)
+        train(
+            model,
+            train_loader,
+            valid_loader,
+            criterion,
+            optimizer,
+            False,
+            log_dir,
+            model_dir,
+            params)
 
         test_cnn(train_loader, "train", fi, criterion, options)
         test_cnn(valid_loader, "validation", fi, criterion, options)
@@ -283,5 +311,7 @@ if __name__ == "__main__":
     commandline_to_json(commandline, "CNN")
     options = commandline[0]
     if commandline[1]:
-        raise Exception("unknown arguments: %s" % (parser.parse_known_args()[1]))
+        raise Exception(
+            "unknown arguments: %s" %
+            (parser.parse_known_args()[1]))
     train_CNN_bad_data_split(options)


### PR DESCRIPTION
Outputs of train pipelines were changed:
- different initializations were abandonned,
- fold directories were put before the models / logs directories,
- files were renamed (in `train` and `classify`).