### PR TITLE
Add warning if only one class is detected

### DIFF
--- a/clinicadl/clinicadl/tools/deep_learning/cnn_utils.py
+++ b/clinicadl/clinicadl/tools/deep_learning/cnn_utils.py
@@ -343,20 +343,25 @@ def concat_multi_cnn_results(output_dir, fold, selection, mode, dataset, num_cnn
         cnn_metrics_path = os.path.join(performance_dir, '%s_%s_level_metrics.tsv' % (dataset, mode))
 
         cnn_pred_df = pd.read_csv(cnn_pred_path, sep='\t')
-        cnn_metrics_df = pd.read_csv(cnn_metrics_path, sep='\t')
         prediction_df = pd.concat([prediction_df, cnn_pred_df])
-        metrics_df = pd.concat([metrics_df, cnn_metrics_df])
+        os.remove(cnn_pred_path)
+
+        if os.path.exists(cnn_metrics_path):
+            cnn_metrics_df = pd.read_csv(cnn_metrics_path, sep='\t')
+            metrics_df = pd.concat([metrics_df, cnn_metrics_df])
+            os.remove(cnn_metrics_path)
 
         # Clean unused files
-        os.remove(cnn_pred_path)
-        os.remove(cnn_metrics_path)
         if len(os.listdir(performance_dir)) == 0:
             os.rmdir(performance_dir)
         if len(os.listdir(cnn_dir)) == 0:
             os.rmdir(cnn_dir)
 
     prediction_df.reset_index(drop=True, inplace=True)
-    metrics_df.reset_index(drop=True, inplace=True)
+    if len(metrics_df) == 0:
+        metrics_df = None
+    else:
+        metrics_df.reset_index(drop=True, inplace=True)
     mode_level_to_tsvs(output_dir, prediction_df, metrics_df, fold, selection, mode, dataset)
 
 

--- a/clinicadl/clinicadl/tools/deep_learning/cnn_utils.py
+++ b/clinicadl/clinicadl/tools/deep_learning/cnn_utils.py
@@ -313,7 +313,6 @@ def mode_level_to_tsvs(output_dir, results_df, metrics, fold, selection, mode, d
     else:
         performance_dir = os.path.join(output_dir, 'fold-%i' % fold, 'cnn_classification', 'cnn-%i' % cnn_index,
                                        selection)
-        metrics["%s_id" % mode] = cnn_index
 
     if not os.path.exists(performance_dir):
         os.makedirs(performance_dir)
@@ -321,16 +320,16 @@ def mode_level_to_tsvs(output_dir, results_df, metrics, fold, selection, mode, d
     results_df.to_csv(os.path.join(performance_dir, '%s_%s_level_prediction.tsv' % (dataset, mode)), index=False,
                       sep='\t')
 
-    if metrics is None:
-        pass
-    elif isinstance(metrics, dict):
-        pd.DataFrame(metrics, index=[0]).to_csv(os.path.join(performance_dir, '%s_%s_level_metrics.tsv' % (dataset, mode)),
-                                                index=False, sep='\t')
-    elif isinstance(metrics, pd.DataFrame):
-        metrics.to_csv(os.path.join(performance_dir, '%s_%s_level_metrics.tsv' % (dataset, mode)),
-                       index=False, sep='\t')
-    else:
-        raise ValueError("Bad type for metrics: %s. Must be dict or DataFrame." % type(metrics).__name__)
+    if metrics is not None:
+        metrics["%s_id" % mode] = cnn_index
+        if isinstance(metrics, dict):
+            pd.DataFrame(metrics, index=[0]).to_csv(os.path.join(performance_dir, '%s_%s_level_metrics.tsv' % (dataset, mode)),
+                                                    index=False, sep='\t')
+        elif isinstance(metrics, pd.DataFrame):
+            metrics.to_csv(os.path.join(performance_dir, '%s_%s_level_metrics.tsv' % (dataset, mode)),
+                           index=False, sep='\t')
+        else:
+            raise ValueError("Bad type for metrics: %s. Must be dict or DataFrame." % type(metrics).__name__)
 
 
 def concat_multi_cnn_results(output_dir, fold, selection, mode, dataset, num_cnn):

--- a/clinicadl/clinicadl/tools/deep_learning/data.py
+++ b/clinicadl/clinicadl/tools/deep_learning/data.py
@@ -7,6 +7,7 @@ from os import path
 from torch.utils.data import Dataset
 import torchvision.transforms as transforms
 import abc
+import warnings
 from clinicadl.tools.inputs.filename_types import FILENAME_TYPE
 
 
@@ -56,6 +57,15 @@ class MRIDataset(Dataset):
         if not mandatory_col.issubset(set(self.df.columns.values)):
             raise Exception("the data file is not in the correct format."
                             "Columns should include %s" % mandatory_col)
+
+        unique_diagnoses = set(self.df.diagnosis)
+        unique_codes = set()
+        for diagnosis in unique_diagnoses:
+            unique_codes.add(self.diagnosis_code[diagnosis])
+        if len(unique_codes) == 1:
+            warnings.warn("The diagnoses found in the DataFrame %s only corresponds to one class %s. "
+                          "If you want to run a binary classification please change the labels involved."
+                          % (unique_diagnoses, unique_codes))
 
         self.elem_per_image = self.num_elem_per_image()
 

--- a/clinicadl/clinicadl/tools/deep_learning/data.py
+++ b/clinicadl/clinicadl/tools/deep_learning/data.py
@@ -443,7 +443,7 @@ def return_dataset(mode, input_dir, data_df, preprocessing,
             transformations=transformations,
             labels=labels
         )
-    if mode == "patch":
+    elif mode == "patch":
         return MRIDatasetPatch(
             input_dir,
             data_df,

--- a/clinicadl/tests/test_classify.py
+++ b/clinicadl/tests/test_classify.py
@@ -12,7 +12,7 @@ from os.path import join, exists
 ])
 def classify_commands(request):
 
-    out_filename = 'fold-0/cnn_classification/best_balanced_accuracy/DB-TEST_image_level_prediction.tsv'
+    out_filename = 'fold-0/cnn_classification/best_balanced_accuracy/test-OASIS_image_level_prediction.tsv'
     if request.param == 'classify_image':
         data_folder = 'data/models/image_model_baseline_AD_CN_single_fold/'
         test_input = [


### PR DESCRIPTION
The management of labels may not be easy to understand for newcomers, so a warning was added in case they perform a classification on classes with same label.
This closes #86.