### PR TITLE
Fix typo, link, title and clinicadl occurences in doc

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-You will find below the steps for installing `clinicadl` on Linux or Mac.
+You will find below the steps for installing ClinicaDL on Linux or Mac.
 Please do not hesitate to contact us on the
 [forum](https://groups.google.com/forum/#!forum/clinica-user) or
 [GitHub](https://github.com/aramis-lab/clinicadl/issues)

--- a/docs/RandomSearch.md
+++ b/docs/RandomSearch.md
@@ -18,7 +18,7 @@ that they should be given a unique value.
 The values of the variables that can be set in `random_search.json` correspond to
 the options of the [train function](./Train/Introduction.md) except for the 
 **Computational resources**, **Cross-validation arguments** and `output_directory`
-that are defined with the commandline arguments.
+that are defined with the command line arguments.
 Some variables were also added to sample the architecture of the network.
 
 ## Prerequisites
@@ -32,7 +32,7 @@ Moreover, there should be a CAPS, obtained running the `t1-linear` pipeline of C
 
 This task can be run with the following command line:
 ```Text
-clinicadl random-search generate <launch_directory> <name>
+clinicadl random-search <launch_directory> <name>
 
 ```
 where:

--- a/docs/Train/Details.md
+++ b/docs/Train/Details.md
@@ -13,7 +13,7 @@ Here is a 2D example of the standard layer of pytorch `nn.MaxPool2d`:
 <img src="https://drive.google.com/uc?id=1qh9M9r9mfpZeSD1VjOGQAl8zWqBLmcKz" style="height: 200px;" alt="animation of classical max pooling">
 
 The last column may not be used depending on the size of the kernel/input and stride value. 
-To avoid this, pooling layers with adaptive padding `PadMaxPool3d` were implemented in `clinicadl` to exploit information from the whole feature map.
+To avoid this, pooling layers with adaptive padding `PadMaxPool3d` were implemented in ClinicaDL to exploit information from the whole feature map.
 
 <img src="https://drive.google.com/uc?id=14R_LCTiV0N6ZXm-3wQCj_Gtc1LsXdQq_" style="height: 200px;" alt="animation of max pooling with adaptive pooling">
 

--- a/docs/Train/Resume.md
+++ b/docs/Train/Resume.md
@@ -1,4 +1,4 @@
-# `clinicadl train resume` - Resume a prematurely stopped job
+# `resume` - Resume a prematurely stopped job
 
 This functionality allows to resume a prematurely stopped job trained with
 [`clinicadl train`](Introduction.md) of [`clinicadl random-search generate`](../RandomSearch.md) tasks.
@@ -25,7 +25,7 @@ extract` to obtain the tensor versions of the images.
 ## Running the task
 This task can be run with the following command line:
 ```Text
-clinicadl train resume <model_path>
+clinicadl resume <model_path>
 
 ```
 where `model_path` (str) is a path to the [MAPS folder](../Introduction.md) of the model.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# `clinicadl` Documentation
+# ClinicaDL Documentation
 
 ClinicaDL is the deep learning extension of [Clinica](https://aramislab.paris.inria.fr/clinica/docs/public/latest/),
 an open-source Python library for neuroimaging preprocessing and analysis.
@@ -20,11 +20,11 @@ before starting your project!
 
 See [Installation](./Installation.md) section for detailed instructions.
 
-`clinicadl` can be installed on Mac OS X and Linux machines, and possibly on Windows computers with a Linux Virtual Machine.
+ClinicaDL can be installed on Mac OS X and Linux machines, and possibly on Windows computers with a Linux Virtual Machine.
 
-We assume that users installing and using `clinicadl` are comfortable using the command line.
+We assume that users installing and using ClinicaDL are comfortable using the command line.
 
-## User documentation (`clinicadl`)
+## User documentation (ClinicaDL)
 
 ### Prepare your metadata
 - `clinicadl tsvtool` - [Handle TSV files for metadata processing and data splits](./TSVTools.md)
@@ -60,22 +60,22 @@ Updated versions of most representative models are available [here](https://aram
 
 ## Support
 - [Report an issue on GitHub](https://github.com/aramis-lab/clinicadl/issues)
-- Use the [`clinicadl` Google Group](https://groups.google.com/forum/#!forum/clinica-user) to ask for help!
+- Use the [ClinicaDL GitHub Discussion](https://github.com/aramis-lab/clinicadl/discussions) to ask for help!
 
 ## Contributions
 If you want to contribute but are not familiar with GitHub, please read the [Contribute](Contribute/Newcomers.md) section.
 You will also find how to [run the test suite](Contribute/Test.md) to check that your modifications are ready to be integrated.
 
 ## License
-`clinicadl` is distributed under the terms of the MIT license given [here](https://github.com/aramis-lab/clinicadl/blob/dev/LICENSE.txt).
+ClinicaDL is distributed under the terms of the MIT license given [here](https://github.com/aramis-lab/clinicadl/blob/dev/LICENSE.txt).
 
-## Citing `clinicadl`
-For publications or communications using `clinicadl`, please cite [[Wen et al., 2020](https://doi.org/10.1016/j.media.2020.101694)] 
+## Citing ClinicaDL
+For publications or communications using ClinicaDL, please cite [[Wen et al., 2020](https://doi.org/10.1016/j.media.2020.101694)] 
 as well as the references mentioned on the wiki page of the pipelines you used 
 (for example, citing PyTorch when using the `extract` pipeline).
 
 !!! info "Disclaimer"
-    `clinicadl` is a software for research studies. It is not intended for use in medical routine.
+    ClinicaDL is a software for research studies. It is not intended for use in medical routine.
 
 ---
 


### PR DESCRIPTION
Fix documentation: 

- change `clinicadl` by ClinicaDL when necessary,
- new link to github discussion instead of google groups,
- small typo and title correction.