### PR TITLE
Added resume to command line

### DIFF
--- a/clinicadl/clinicadl/cmdline.py
+++ b/clinicadl/clinicadl/cmdline.py
@@ -8,6 +8,7 @@ from clinicadl.interpret.interpret_cli import cli as interpret_cli
 from clinicadl.predict.predict_cli import cli as predict_cli
 from clinicadl.quality_check.qc_cli import cli as qc_cli
 from clinicadl.random_search.random_search_cli import cli as random_search_cli
+from clinicadl.train.resume_cli import cli as resume_cli
 from clinicadl.train.train_cli import cli as train_cli
 from clinicadl.tsvtools.cli import cli as tsvtools_cli
 
@@ -63,6 +64,7 @@ def cli(verbosity):
 
 cli.add_command(tsvtools_cli)
 cli.add_command(train_cli)
+cli.add_command(resume_cli)
 cli.add_command(generate_cli)
 cli.add_command(extract_cli)
 cli.add_command(predict_cli)

--- a/clinicadl/clinicadl/train/resume_cli.py
+++ b/clinicadl/clinicadl/train/resume_cli.py
@@ -1,0 +1,19 @@
+import click
+
+from clinicadl.utils import cli_param
+
+
+@click.command(name="resume")
+@cli_param.argument.input_maps
+def cli(maps_directory):
+    """Resume training job in specified maps.
+
+    INPUT_MAPS_DIRECTORY is the path to the MAPS folder where training job has started.
+    """
+    from .resume import automatic_resume
+
+    automatic_resume(maps_directory)
+
+
+if __name__ == "__main__":
+    cli()

--- a/clinicadl/tests/test_cli.py
+++ b/clinicadl/tests/test_cli.py
@@ -16,6 +16,7 @@ from clinicadl.cmdline import cli
         "predict",
         "quality-check",
         "random-search",
+        "resume",
         "train",
         "tsvtool",
     ]


### PR DESCRIPTION
Small PR to add `resume` to command line. This pipeline was in the doc but not yet implemented with Click. This PR fix this.