### PR TITLE
Fix `clinicadl generate` module in last release

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
              conda activate clinicadl_test
              echo "Install clinicadl using pip..."
              cd $WORKSPACE
-             pip install -e .
+             pip install  .
              pip install -r ./requirements-dev.txt
              # Show clinicadl help message
              echo "Display clinicadl help message"


### PR DESCRIPTION
It seems that generate is not seen as a package (see #208 ).
This PR should fix this issue.
(I suggest to merge it to master and release quickly as this blocks users).