### PR TITLE
Fix train cli

### DIFF
--- a/clinicadl/train/train_cli.py
+++ b/clinicadl/train/train_cli.py
@@ -277,9 +277,6 @@ def cli(
     """
     from clinicadl.utils.cmdline_utils import check_gpu
 
-    if gpu:
-        check_gpu()
-
     from .launch import train
     from .train_utils import get_train_dict
 
@@ -331,7 +328,9 @@ def cli(
 
     if gpu is not None:
         train_dict["use_cpu"] = not gpu
-    if n_proc:
+    if not train_dict["use_cpu"]:
+        check_gpu()
+    if n_proc is not None:
         train_dict["num_workers"] = n_proc
     if normalize is not None:
         train_dict["minmaxnormalization"] = normalize


### PR DESCRIPTION
Small fix on train cli:
- Check GPU was done before final value assignment
- In the test `if n_proc`, if n_proc is 0 then it doesn't work which cause some issue with Pytorch [W ParallelNative.cpp:206].