### PR TITLE
Update torchvision in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ toml
 nilearn
 nipy
 torch >= 1.8
+torchvision
 pandas
 colorama
 tensorboard

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         "numpy>=1.17",
         "clinica>=0.5.0",
         "torch>=1.8",
+        "torchvision",
         "tensorboard",
         "toml",
         "click>=7.0",


### PR DESCRIPTION
Update torchvision in requirements (not present). This package has been removed from Clinica's requirements and now it should be explicitly declared for ClinicaDL.