### PR TITLE
Extract name

### DIFF
--- a/clinicadl/extract/extract_cli.py
+++ b/clinicadl/extract/extract_cli.py
@@ -12,6 +12,7 @@ from .extract_utils import get_parameters_dict
 @cli_param.argument.caps_directory
 @cli_param.argument.modality
 @cli_param.option.subjects_sessions_tsv
+@cli_param.option.json_name
 @cli_param.option.use_uncropped_image
 @cli_param.option.acq_label
 @cli_param.option.suvr_reference_region
@@ -20,6 +21,7 @@ def image_cli(
     caps_directory: str,
     modality: str,
     subjects_sessions_tsv: Optional[str] = None,
+    json_name: str = None,
     use_uncropped_image: bool = False,
     acq_label: Optional[str] = None,
     suvr_reference_region: Optional[str] = None,
@@ -35,6 +37,7 @@ def image_cli(
         modality,
         "image",
         False,
+        json_name,
         use_uncropped_image,
         custom_suffix,
         acq_label,
@@ -52,6 +55,7 @@ def image_cli(
 @cli_param.argument.modality
 @cli_param.option.save_features
 @cli_param.option.subjects_sessions_tsv
+@cli_param.option.json_name
 @cli_param.option.use_uncropped_image
 @click.option(
     "-ps",
@@ -75,6 +79,7 @@ def patch_cli(
     modality: str,
     save_features: bool = False,
     subjects_sessions_tsv: Optional[str] = None,
+    json_name: str = None,
     use_uncropped_image: bool = False,
     patch_size: int = 50,
     stride_size: int = 50,
@@ -92,6 +97,7 @@ def patch_cli(
         modality,
         "patch",
         save_features,
+        json_name,
         use_uncropped_image,
         custom_suffix,
         acq_label,
@@ -112,6 +118,7 @@ def patch_cli(
 @cli_param.argument.modality
 @cli_param.option.save_features
 @cli_param.option.subjects_sessions_tsv
+@cli_param.option.json_name
 @cli_param.option.use_uncropped_image
 @click.option(
     "-sd",
@@ -150,6 +157,7 @@ def slice_cli(
     modality: str,
     save_features: bool = False,
     subjects_sessions_tsv: Optional[str] = None,
+    json_name: str = None,
     use_uncropped_image: bool = False,
     slice_direction: int = 0,
     slice_mode: str = "rgb",
@@ -168,6 +176,7 @@ def slice_cli(
         modality,
         "slice",
         save_features,
+        json_name,
         use_uncropped_image,
         custom_suffix,
         acq_label,
@@ -189,6 +198,7 @@ def slice_cli(
 @cli_param.argument.modality
 @cli_param.option.save_features
 @cli_param.option.subjects_sessions_tsv
+@cli_param.option.json_name
 @cli_param.option.use_uncropped_image
 @click.option(
     "--roi_list",
@@ -230,6 +240,7 @@ def roi_cli(
     modality: str,
     save_features: bool = False,
     subjects_sessions_tsv: Optional[str] = None,
+    json_name: str = None,
     use_uncropped_image: bool = False,
     roi_list: list = [],
     roi_uncrop_output: bool = False,
@@ -249,6 +260,7 @@ def roi_cli(
         modality,
         "roi",
         save_features,
+        json_name,
         use_uncropped_image,
         custom_suffix,
         acq_label,

--- a/clinicadl/extract/extract_cli.py
+++ b/clinicadl/extract/extract_cli.py
@@ -12,7 +12,7 @@ from .extract_utils import get_parameters_dict
 @cli_param.argument.caps_directory
 @cli_param.argument.modality
 @cli_param.option.subjects_sessions_tsv
-@cli_param.option.json_name
+@cli_param.option.extract_json
 @cli_param.option.use_uncropped_image
 @cli_param.option.acq_label
 @cli_param.option.suvr_reference_region
@@ -21,7 +21,7 @@ def image_cli(
     caps_directory: str,
     modality: str,
     subjects_sessions_tsv: Optional[str] = None,
-    json_name: str = None,
+    extract_json: str = None,
     use_uncropped_image: bool = False,
     acq_label: Optional[str] = None,
     suvr_reference_region: Optional[str] = None,
@@ -37,7 +37,7 @@ def image_cli(
         modality,
         "image",
         False,
-        json_name,
+        extract_json,
         use_uncropped_image,
         custom_suffix,
         acq_label,
@@ -55,7 +55,7 @@ def image_cli(
 @cli_param.argument.modality
 @cli_param.option.save_features
 @cli_param.option.subjects_sessions_tsv
-@cli_param.option.json_name
+@cli_param.option.extract_json
 @cli_param.option.use_uncropped_image
 @click.option(
     "-ps",
@@ -79,7 +79,7 @@ def patch_cli(
     modality: str,
     save_features: bool = False,
     subjects_sessions_tsv: Optional[str] = None,
-    json_name: str = None,
+    extract_json: str = None,
     use_uncropped_image: bool = False,
     patch_size: int = 50,
     stride_size: int = 50,
@@ -97,7 +97,7 @@ def patch_cli(
         modality,
         "patch",
         save_features,
-        json_name,
+        extract_json,
         use_uncropped_image,
         custom_suffix,
         acq_label,
@@ -118,7 +118,7 @@ def patch_cli(
 @cli_param.argument.modality
 @cli_param.option.save_features
 @cli_param.option.subjects_sessions_tsv
-@cli_param.option.json_name
+@cli_param.option.extract_json
 @cli_param.option.use_uncropped_image
 @click.option(
     "-sd",
@@ -157,7 +157,7 @@ def slice_cli(
     modality: str,
     save_features: bool = False,
     subjects_sessions_tsv: Optional[str] = None,
-    json_name: str = None,
+    extract_json: str = None,
     use_uncropped_image: bool = False,
     slice_direction: int = 0,
     slice_mode: str = "rgb",
@@ -176,7 +176,7 @@ def slice_cli(
         modality,
         "slice",
         save_features,
-        json_name,
+        extract_json,
         use_uncropped_image,
         custom_suffix,
         acq_label,
@@ -198,7 +198,7 @@ def slice_cli(
 @cli_param.argument.modality
 @cli_param.option.save_features
 @cli_param.option.subjects_sessions_tsv
-@cli_param.option.json_name
+@cli_param.option.extract_json
 @cli_param.option.use_uncropped_image
 @click.option(
     "--roi_list",
@@ -240,7 +240,7 @@ def roi_cli(
     modality: str,
     save_features: bool = False,
     subjects_sessions_tsv: Optional[str] = None,
-    json_name: str = None,
+    extract_json: str = None,
     use_uncropped_image: bool = False,
     roi_list: list = [],
     roi_uncrop_output: bool = False,
@@ -260,7 +260,7 @@ def roi_cli(
         modality,
         "roi",
         save_features,
-        json_name,
+        extract_json,
         use_uncropped_image,
         custom_suffix,
         acq_label,

--- a/clinicadl/extract/extract_utils.py
+++ b/clinicadl/extract/extract_utils.py
@@ -46,14 +46,18 @@ def get_parameters_dict(
         parameters["acq_label"] = acq_label
         parameters["suvr_reference_region"] = suvr_reference_region
 
-    if json_name is None:
-        parameters["json_name"] = f"extract_{int(time())}.json"
-    elif not json_name.endswith(".json"):
-        parameters["json_name"] = f"{json_name}.json"
-    else:
-        parameters["json_name"] = json_name
+    parameters["json_name"] = compute_json_name(json_name)
 
     return parameters
+
+
+def compute_json_name(json_name: str) -> str:
+    if json_name is None:
+        return f"extract_{int(time())}.json"
+    elif not json_name.endswith(".json"):
+        return f"{json_name}.json"
+    else:
+        return json_name
 
 
 def compute_folder_and_file_type(

--- a/clinicadl/extract/extract_utils.py
+++ b/clinicadl/extract/extract_utils.py
@@ -11,7 +11,7 @@ def get_parameters_dict(
     modality: str,
     extract_method: str,
     save_features: bool,
-    json_name: str,
+    extract_json: str,
     use_uncropped_image: bool,
     custom_suffix: str,
     acq_label: str,
@@ -23,7 +23,7 @@ def get_parameters_dict(
         extract_method: mode of extraction (image, slice, patch, roi).
         save_features: If True modes are extracted, else images are extracted
             and the extraction of modes is done on-the-fly during training.
-        json_name: Name of the JSON file created to sum up the arguments of tensor extraction.
+        extract_json: Name of the JSON file created to sum up the arguments of tensor extraction.
         use_uncropped_image: If True the cropped version of the image is used
             (specific to t1-linear and pet-linear).
         custom_suffix: string used to identify images when modality is custom.
@@ -46,18 +46,18 @@ def get_parameters_dict(
         parameters["acq_label"] = acq_label
         parameters["suvr_reference_region"] = suvr_reference_region
 
-    parameters["json_name"] = compute_json_name(json_name)
+    parameters["extract_json"] = compute_extract_json(extract_json)
 
     return parameters
 
 
-def compute_json_name(json_name: str) -> str:
-    if json_name is None:
+def compute_extract_json(extract_json: str) -> str:
+    if extract_json is None:
         return f"extract_{int(time())}.json"
-    elif not json_name.endswith(".json"):
-        return f"{json_name}.json"
+    elif not extract_json.endswith(".json"):
+        return f"{extract_json}.json"
     else:
-        return json_name
+        return extract_json
 
 
 def compute_folder_and_file_type(

--- a/clinicadl/extract/extract_utils.py
+++ b/clinicadl/extract/extract_utils.py
@@ -1,5 +1,6 @@
 # coding: utf8
 from os import path
+from time import time
 from typing import Any, Dict, List, Tuple, Union
 
 import numpy as np
@@ -10,6 +11,7 @@ def get_parameters_dict(
     modality: str,
     extract_method: str,
     save_features: bool,
+    json_name: str,
     use_uncropped_image: bool,
     custom_suffix: str,
     acq_label: str,
@@ -21,6 +23,7 @@ def get_parameters_dict(
         extract_method: mode of extraction (image, slice, patch, roi).
         save_features: If True modes are extracted, else images are extracted
             and the extraction of modes is done on-the-fly during training.
+        json_name: Name of the JSON file created to sum up the arguments of tensor extraction.
         use_uncropped_image: If True the cropped version of the image is used
             (specific to t1-linear and pet-linear).
         custom_suffix: string used to identify images when modality is custom.
@@ -42,6 +45,13 @@ def get_parameters_dict(
     if modality == "pet-linear":
         parameters["acq_label"] = acq_label
         parameters["suvr_reference_region"] = suvr_reference_region
+
+    if json_name is None:
+        parameters["json_name"] = f"extract_{int(time())}.json"
+    elif not json_name.endswith(".json"):
+        parameters["json_name"] = f"{json_name}.json"
+    else:
+        parameters["json_name"] = json_name
 
     return parameters
 

--- a/clinicadl/generate/generate.py
+++ b/clinicadl/generate/generate.py
@@ -14,6 +14,7 @@ import pandas as pd
 import torch
 from clinica.utils.inputs import RemoteFileStructure, clinica_file_reader, fetch_file
 
+from clinicadl.extract.extract_utils import compute_json_name
 from clinicadl.utils.caps_dataset.data import CapsDataset
 from clinicadl.utils.maps_manager.iotools import check_and_clean, commandline_to_json
 from clinicadl.utils.preprocessing import write_preprocessing
@@ -295,9 +296,22 @@ def generate_shepplogan_dataset(
     output_dir: str,
     img_size: int,
     labels_distribution: Dict[str, Tuple[float, float, float]],
+    json_name: str = None,
     samples: int = 100,
     smoothing: bool = True,
 ):
+    """
+    Creates a CAPS data set of synthetic data based on Shepp-Logan phantom.
+    Source NifTi files are not extracted, but directly the slices as tensors.
+
+    Args:
+        output_dir: path to the CAPS created.
+        img_size: size of the square image.
+        labels_distribution: gives the proportions of the three subtypes (ordered in a tuple) for each label.
+        json_name: name of the JSON file in which generation details are stored.
+        samples: number of samples generated per class.
+        smoothing: if True, an additional random smoothing is performed on top of all operations on each image.
+    """
 
     check_and_clean(join(output_dir, "subjects"))
     commandline_to_json(
@@ -366,6 +380,7 @@ def generate_shepplogan_dataset(
         "mode": "slice",
         "use_uncropped_image": False,
         "prepare_dl": True,
+        "json_name": compute_json_name(json_name),
         "slice_direction": 2,
         "slice_mode": "single",
         "discarded_slices": 0,

--- a/clinicadl/generate/generate.py
+++ b/clinicadl/generate/generate.py
@@ -14,7 +14,7 @@ import pandas as pd
 import torch
 from clinica.utils.inputs import RemoteFileStructure, clinica_file_reader, fetch_file
 
-from clinicadl.extract.extract_utils import compute_json_name
+from clinicadl.extract.extract_utils import compute_extract_json
 from clinicadl.utils.caps_dataset.data import CapsDataset
 from clinicadl.utils.maps_manager.iotools import check_and_clean, commandline_to_json
 from clinicadl.utils.preprocessing import write_preprocessing
@@ -296,7 +296,7 @@ def generate_shepplogan_dataset(
     output_dir: str,
     img_size: int,
     labels_distribution: Dict[str, Tuple[float, float, float]],
-    json_name: str = None,
+    extract_json: str = None,
     samples: int = 100,
     smoothing: bool = True,
 ):
@@ -308,7 +308,7 @@ def generate_shepplogan_dataset(
         output_dir: path to the CAPS created.
         img_size: size of the square image.
         labels_distribution: gives the proportions of the three subtypes (ordered in a tuple) for each label.
-        json_name: name of the JSON file in which generation details are stored.
+        extract_json: name of the JSON file in which generation details are stored.
         samples: number of samples generated per class.
         smoothing: if True, an additional random smoothing is performed on top of all operations on each image.
     """
@@ -380,7 +380,7 @@ def generate_shepplogan_dataset(
         "mode": "slice",
         "use_uncropped_image": False,
         "prepare_dl": True,
-        "json_name": compute_json_name(json_name),
+        "extract_json": compute_extract_json(extract_json),
         "slice_direction": 2,
         "slice_mode": "single",
         "discarded_slices": 0,

--- a/clinicadl/generate/generate_shepplogan_cli.py
+++ b/clinicadl/generate/generate_shepplogan_cli.py
@@ -6,6 +6,7 @@ from clinicadl.utils import cli_param
 @click.command(name="shepplogan")
 @cli_param.argument.generated_caps
 @cli_param.option.n_subjects
+@cli_param.option.json_name
 @click.option(
     "--image_size",
     help="Size in pixels of the squared images.",
@@ -36,6 +37,7 @@ from clinicadl.utils import cli_param
 def cli(
     generated_caps_directory,
     image_size,
+    json_name,
     ad_subtypes_distribution,
     cn_subtypes_distribution,
     n_subjects,
@@ -56,6 +58,7 @@ def cli(
         output_dir=generated_caps_directory,
         img_size=image_size,
         labels_distribution=labels_distribution,
+        json_name=json_name,
         samples=n_subjects,
         smoothing=smoothing,
     )

--- a/clinicadl/generate/generate_shepplogan_cli.py
+++ b/clinicadl/generate/generate_shepplogan_cli.py
@@ -6,7 +6,7 @@ from clinicadl.utils import cli_param
 @click.command(name="shepplogan")
 @cli_param.argument.generated_caps
 @cli_param.option.n_subjects
-@cli_param.option.json_name
+@cli_param.option.extract_json
 @click.option(
     "--image_size",
     help="Size in pixels of the squared images.",
@@ -37,7 +37,7 @@ from clinicadl.utils import cli_param
 def cli(
     generated_caps_directory,
     image_size,
-    json_name,
+    extract_json,
     ad_subtypes_distribution,
     cn_subtypes_distribution,
     n_subjects,
@@ -58,7 +58,7 @@ def cli(
         output_dir=generated_caps_directory,
         img_size=image_size,
         labels_distribution=labels_distribution,
-        json_name=json_name,
+        extract_json=extract_json,
         samples=n_subjects,
         smoothing=smoothing,
     )

--- a/clinicadl/utils/cli_param/option.py
+++ b/clinicadl/utils/cli_param/option.py
@@ -90,9 +90,9 @@ subjects_sessions_tsv = click.option(
     type=click.Path(exists=True, resolve_path=True),
     help="TSV file containing a list of subjects with their sessions.",
 )
-json_name = click.option(
-    "-js",
-    "--json_name",
+extract_json = click.option(
+    "-ej",
+    "--extract_json",
     type=str,
     default=None,
     help="Name of the JSON file created to describe the tensor extraction. "

--- a/clinicadl/utils/cli_param/option.py
+++ b/clinicadl/utils/cli_param/option.py
@@ -90,6 +90,15 @@ subjects_sessions_tsv = click.option(
     type=click.Path(exists=True, resolve_path=True),
     help="TSV file containing a list of subjects with their sessions.",
 )
+json_name = click.option(
+    "-js",
+    "--json_name",
+    type=str,
+    default=None,
+    help="Name of the JSON file created to describe the tensor extraction. "
+    "Default will use format extract_{time_stamp}.json",
+)
+
 use_uncropped_image = click.option(
     "-uui",
     "--use_uncropped_image",

--- a/clinicadl/utils/maps_manager/maps_manager.py
+++ b/clinicadl/utils/maps_manager/maps_manager.py
@@ -783,7 +783,7 @@ class MapsManager:
         )
         epoch = log_writer.beginning_epoch
 
-        retain_best = RetainBest(selection_metrics=self.selection_metrics)
+        retain_best = RetainBest(selection_metrics=list(self.selection_metrics))
 
         while epoch < self.epochs and not early_stopping.step(metrics_valid["loss"]):
             logger.info(f"Beginning epoch {epoch}.")

--- a/clinicadl/utils/preprocessing.py
+++ b/clinicadl/utils/preprocessing.py
@@ -23,6 +23,9 @@ def write_preprocessing(preprocessing_dict: Dict[str, Any], caps_directory: str)
 
 
 def read_preprocessing(json_path: str) -> Dict[str, Any]:
+    if not json_path.endswith(".json"):
+        json_path += ".json"
+
     if not os.path.isfile(json_path):
         raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), json_path)
     try:

--- a/clinicadl/utils/preprocessing.py
+++ b/clinicadl/utils/preprocessing.py
@@ -5,15 +5,18 @@ from typing import Any, Dict
 
 
 def write_preprocessing(preprocessing_dict: Dict[str, Any], caps_directory: str):
-    import time
-
     extract_dir = os.path.join(
         caps_directory,
         "tensor_extraction",
     )
-    if not os.path.exists(extract_dir):
-        os.mkdir(extract_dir)
-    json_path = os.path.join(extract_dir, "extract_" + str(int(time.time())) + ".json")
+    os.makedirs(extract_dir, exist_ok=True)
+    json_path = os.path.join(extract_dir, preprocessing_dict["json_name"])
+    if os.path.exists(json_path):
+        raise FileExistsError(
+            f"JSON file at {json_path} already exists. "
+            f"Please choose another name for your preprocessing file."
+        )
+
     with open(json_path, "w") as json_file:
         json.dump(preprocessing_dict, json_file, indent=2)
     return json_path
@@ -26,5 +29,5 @@ def read_preprocessing(json_path: str) -> Dict[str, Any]:
         with open(json_path, "r") as f:
             preprocessing_dict = json.load(f)
     except IOError:
-        raise IOError(f"cannot open json preprocessing file {json_path}")
+        raise IOError(f"Cannot open json preprocessing file {json_path}")
     return preprocessing_dict

--- a/clinicadl/utils/preprocessing.py
+++ b/clinicadl/utils/preprocessing.py
@@ -10,7 +10,7 @@ def write_preprocessing(preprocessing_dict: Dict[str, Any], caps_directory: str)
         "tensor_extraction",
     )
     os.makedirs(extract_dir, exist_ok=True)
-    json_path = os.path.join(extract_dir, preprocessing_dict["json_name"])
+    json_path = os.path.join(extract_dir, preprocessing_dict["extract_json"])
     if os.path.exists(json_path):
         raise FileExistsError(
             f"JSON file at {json_path} already exists. "

--- a/docs/Preprocessing/Extract.md
+++ b/docs/Preprocessing/Extract.md
@@ -29,9 +29,11 @@ which have the same arguments:
   can be `t1-linear` or `pet-linear`. You can choose `custom` if you want to get a
   tensor from a custom filename.
 
-Each sub-command has its own set of options. There is one generic option:
+Each sub-command has its own set of options. There are two generic options:
 
 - `--subjects_sessions_tsv` (Path) is a path to a TSV file listing participant and session IDs. 
+- `--extract_json` (str) is the name of the JSON file that will be created to store all the information
+  of the extraction step. Default will name the JSON file `extract_{time_stamp}.json`.
 
 !!! note "Default values"
     When using patch or slice extraction, default values were set according to
@@ -50,13 +52,11 @@ Results are stored in following folder of the
 
 Files are saved with the `.pt` extension and contains tensors in PyTorch format.
 
-A JSON file with timestamp is also stored in the CAPS hierarchy under the `tensor_extraction` folder:
+A JSON file is also stored in the CAPS hierarchy under the `tensor_extraction` folder:
 ```console
 CAPS_DIRECTORY
 └── tensor_extraction
-        ├── extract_XXXXXXXXXX.json
-        ├── ...
-        └── extract_YYYYYYYYY.json
+        └── <extract_json>
  
 ```
 These files are compulsory to run the [train](../Train/Introduction.md#running-the-task) command. 
@@ -70,7 +70,7 @@ The suffix represents the initial modality (it can be for example `T1w`).
 
 !!! Warning!
     The default behavior of the pipeline is to only extract images even if another extraction method is specified.
-    However all the options will be saved in the preprocessing JSON file and then the extraction is done
+    However, all the options will be saved in the preprocessing JSON file and then the extraction is done
     when data is loaded during the training. If you want to save the extracted method tensors in the CAPS, you have to add the `--save-features` flag.
 
 ### `image`

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,7 +1,6 @@
 # coding: utf8
 
 import warnings
-from os import pardir
 from typing import Any, Dict, List
 
 warnings.filterwarnings("ignore")
@@ -155,7 +154,7 @@ def test_extract():
                 parameters["acq_label"] = "av45"
                 parameters["suvr_reference_region"] = "pons2"
                 parameters["use_uncropped_image"] = False
-                parameters["json_name"] = f"{modality}_mode-{parameters['mode']}"
+                parameters["extract_json"] = f"{modality}_mode-{parameters['mode']}"
                 extract_generic(root, parameters)
 
             elif modality == "custom":
@@ -164,14 +163,14 @@ def test_extract():
                     "custom_suffix"
                 ] = "graymatter_space-Ixi549Space_modulated-off_probability.nii.gz"
                 parameters["roi_custom_template"] = "Ixi549Space"
-                parameters["json_name"] = f"{modality}_mode-{parameters['mode']}"
+                parameters["extract_json"] = f"{modality}_mode-{parameters['mode']}"
                 extract_generic(root, parameters)
 
             elif modality == "t1-linear":
                 for flag in uncropped_image:
                     parameters["use_uncropped_image"] = flag
                     parameters[
-                        "json_name"
+                        "extract_json"
                     ] = f"{modality}_crop-{not flag}_mode-{parameters['mode']}"
                     extract_generic(root, parameters)
             else:

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -2,6 +2,7 @@
 
 import warnings
 from os import pardir
+from typing import Any, Dict, List
 
 warnings.filterwarnings("ignore")
 
@@ -140,7 +141,7 @@ def test_extract():
         "roi_custom_mask_pattern": "",
     }
 
-    data = [image_params, slice_params, patch_params, roi_params]
+    data: List[Dict[str, Any]] = [image_params, slice_params, patch_params, roi_params]
 
     for parameters in data:
 
@@ -154,6 +155,7 @@ def test_extract():
                 parameters["acq_label"] = "av45"
                 parameters["suvr_reference_region"] = "pons2"
                 parameters["use_uncropped_image"] = False
+                parameters["json_name"] = f"{modality}_mode-{parameters['mode']}"
                 extract_generic(root, parameters)
 
             elif modality == "custom":
@@ -162,11 +164,15 @@ def test_extract():
                     "custom_suffix"
                 ] = "graymatter_space-Ixi549Space_modulated-off_probability.nii.gz"
                 parameters["roi_custom_template"] = "Ixi549Space"
+                parameters["json_name"] = f"{modality}_mode-{parameters['mode']}"
                 extract_generic(root, parameters)
 
             elif modality == "t1-linear":
                 for flag in uncropped_image:
                     parameters["use_uncropped_image"] = flag
+                    parameters[
+                        "json_name"
+                    ] = f"{modality}_crop-{not flag}_mode-{parameters['mode']}"
                     extract_generic(root, parameters)
             else:
                 raise NotImplementedError(


### PR DESCRIPTION
Closes #242.
When the user choses the name of the JSON file, it may not follow the convention `extract_XXX.json` anymore.
If the user forgets to add the JSON extension on writing or reading, it is added automatically by ClinicaDL.