### PR TITLE
Rh doc

### DIFF
--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -24,7 +24,7 @@ applied to a particular deep learning framework. The hierarchy is organized acco
 **selection metric** and **data group** used.
 
 1. **fold**: In ClinicaDL, a training procedure consists in training one model per train / validation split defined by the validation
-procedure. Then the MAPS contains `N` folders named `fold-<i>` with i between 0 and N-1 containing the best networks obtained
+procedure. Then the MAPS contains `N` folders named `split-<i>` with i between 0 and N-1 containing the best networks obtained
 for the `i`-th train / validation split.
 2. **selection metric**: for each fold, one network is selected per `selection_metrics` asked by the user (see [Implementation Details](Train/Details.md#model-selection)
 for more information). The output folder containing all information linked to a network selected according to a metric `metric` is named
@@ -51,7 +51,7 @@ An example of a MAPS structure is given below:
 ```Text
 <maps_directory>
 ├── environment.txt
-├── fold-0
+├── split-0
 │       ├── best-loss
 │       │       ├── model.pth.tar
 │       │       ├── train
@@ -69,18 +69,18 @@ An example of a MAPS structure is given below:
 │               └── training.tsv
 ├── groups
 │       ├── train
-│       │       ├── fold-0
+│       │       ├── split-0
 │       │       │       ├── data.tsv
 │       │       │       └── maps.json
-│       │       └── fold-1
+│       │       └── split-1
 │       │               ├── data.tsv
 │       │               └── maps.json
 │       ├── train+validation.tsv
 │       └── validation
-│               ├── fold-0
+│               ├── split-0
 │               │       ├── data.tsv
 │               │       └── maps.json
-│               └── fold-1
+│               └── split-1
 │                       ├── data.tsv
 │                       └── maps.json
 └── maps.json
@@ -95,35 +95,35 @@ The first level of the MAPS hierarchy contains the following files:
 ```Text
 <maps_directory>
 ├── environment.txt
-├── fold-0
+├── split-0
 ├── ...
-├── fold-<N-1>
+├── split-<N-1>
 ├── groups
 └── maps.json
 ```
 
 - `environment.txt` contains the description of the environment used for the experiment (output of `pip freeze`).
 - `maps.json` is the global configuration file of the MAPS which contains all the information to reproduce the training procedure.
-- `fold-<i>` is a folder containing the result of the training on the `i`-th split of validation procedure. All possible folds
+- `split-<i>` is a folder containing the result of the training on the `i`-th split of validation procedure. All possible folds
 may not be present if the user chose to train only a subset of folds.
 - `groups` is a folder in which all the data groups used by the MAPS are defined. This folder has the following file system:
     ```Text
     groups
     ├── train+validation.tsv
     ├── train
-    │       ├── fold-0
+    │       ├── split-0
     │       │       ├── data.tsv
     │       │       └── maps.json
     │       ├── ...
-    │       └── fold-<N-1>
+    │       └── split-<N-1>
     │               ├── data.tsv
     │               └── maps.json
     ├── validation
-    │       ├── fold-0
+    │       ├── split-0
     │       │       ├── data.tsv
     │       │       └── maps.json
     │       ├── ...
-    │       └── fold-<N-1>
+    │       └── split-<N-1>
     │               ├── data.tsv
     │               └── maps.json
     └── <data_group>
@@ -139,14 +139,14 @@ may not be present if the user chose to train only a subset of folds.
 
 ### Level 2 - metrics of selection & training logs
 
-The second level corresponds to the content of folder `fold-<i>`. It contains the best models selected during training according to the validation
+The second level corresponds to the content of folder `split-<i>`. It contains the best models selected during training according to the validation
 performance according to a metric `metric`. It also contains the evolution of all evaluation metrics computed on the training
  and validation sets in two different formats:
-- `tensorboard` is a folder containing logs that can be visualized with the command `tensorboard --logdir <maps_directory>/fold-<i>/training_logs/tensorboard`,
+- `tensorboard` is a folder containing logs that can be visualized with the command `tensorboard --logdir <maps_directory>/split-<i>/training_logs/tensorboard`,
 - `training.tsv` is a TSV file.
 
 ```Text
-fold-<i>
+split-<i>
     ├── best-<metric>
     └── training_logs
            ├── tensorboard

--- a/docs/Predict.md
+++ b/docs/Predict.md
@@ -7,7 +7,7 @@ tasks. It can also use any pretrained models if they are structured like a [MAPS
 !!! warning "unbiased image-level results"
     For `patch`, `roi` and `slice` models, the predictions of the models on the
     validation set are needed to perform unbiased ensemble predictions at the image level. 
-    If the tsv files in `fold-<fold>/best-<metric>/validation` were erased the task cannot
+    If the tsv files in `split-<i>/best-<metric>/validation` were erased the task cannot
     be run.
 
 ## Prerequisites
@@ -78,9 +78,9 @@ Results are stored in the MAPS of path `model_path`, according to
 the following file system:
 ```
 <model_path>
-    ├── fold-0  
+    ├── split-0  
     ├── ...  
-    └── fold-<i>
+    └── split-<i>
         └── best-<metric>
                 └── <data_group>
                     ├── description.log

--- a/docs/TSVTools.md
+++ b/docs/TSVTools.md
@@ -142,9 +142,9 @@ Options:
 
     Default value: `100`.
 
-  - `--MCI_sub_categories` (bool) is a flag that disables the special treatment of the MCI set and its subsets.
+  - `--no_mci_sub_categories` (bool) is a flag that disables the special treatment of the MCI set and its subsets.
   This will allow sets with more similar age and sex distributions, but it will cause 
-  data leakage for transfer learning tasks involving these sets. Default value: `False`.
+  data leakage for transfer learning tasks involving these sets. Default value: `True`.
   - `--p_age_threshold` (float) is the threshold on the p-value used for the T-test on age distributions.
   Default value: `0.80`.
   - `--p_sex_threshold` (float) is the threshold on the p-value used for the chi2 test on sex distributions.

--- a/docs/Tensors.md
+++ b/docs/Tensors.md
@@ -1,4 +1,4 @@
-# `save-tensors` - Network output serialization
+# `save-tensors` - Save reconstruction outputs
 
 This tool allows to save the output tensors of a whole [data group](./Introduction.md), associated with the tensor
 corresponding to their input.

--- a/docs/Tensors.md
+++ b/docs/Tensors.md
@@ -61,12 +61,12 @@ the following file system:
 <maps_directory>
     ├── split-0  
     ├── ...  
-    └── split-<fold>
+    └── split-<i>
         └── best-<metric>
                 └── <data_group>
                     └── tensors
-                        ├── <participant_id>_<session_id>_{image|patch|roi|slice}-<i>_input.pt
-                        └── <participant_id>_<session_id>_{image|patch|roi|slice}-<i>_output.pt
+                        ├── <participant_id>_<session_id>_{image|patch|roi|slice}-<X>_input.pt
+                        └── <participant_id>_<session_id>_{image|patch|roi|slice}-<X>_output.pt
 ```
-For each `participant_id`, `session_id` and index of the part of the image (`i`),
+For each `participant_id`, `session_id` and index of the part of the image (`X`),
 the input and the output tensors are saved in.

--- a/docs/Tensors.md
+++ b/docs/Tensors.md
@@ -34,7 +34,7 @@ where:
 Optional arguments:
 
 - **Computational resources**
-    - `--gpu / --no-gpu` (bool) Uses GPU acceleration or not. Default behaviour is to try to use a
+    - `--gpu / --no-gpu` (bool) Uses GPU acceleration or not. Default behavior is to try to use a
       GPU. If not available an error is raised. Use the option `--no-gpu` if running in CPU.
     - `--n_proc` (int) is the number of workers used by the DataLoader. Default: `2`.
     - `--batch_size` (int) is the size of the batch used in the DataLoader. Default: `2`.

--- a/docs/Tensors.md
+++ b/docs/Tensors.md
@@ -59,9 +59,9 @@ Results are stored in the MAPS of path `maps_directory`, according to
 the following file system:
 ```
 <maps_directory>
-    ├── fold-0  
+    ├── split-0  
     ├── ...  
-    └── fold-<fold>
+    └── split-<fold>
         └── best-<metric>
                 └── <data_group>
                     └── tensors

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,7 +91,7 @@ nav:
     - Resume training: Train/Resume.md
     - Implementation details: Train/Details.md
   - Inference using trained models: Predict.md
-  - Network output serialization: Tensors.md
+  - Save reconstruction outputs: Tensors.md
   - Interpretation with gradient maps: Interpret.md
   - Advanced user guide:
       - Customize your training: Contribute/Custom.md


### PR DESCRIPTION
I changed `save-tensor` section name as it was not really clear (@nburgos ) from `Network output serialization` to `Save reconstruction outputs`.

Fixed also an error in the options of `tsvtool split`.