### PR TITLE
Fix toml default arguments reading

### DIFF
--- a/clinicadl/random_search/random_search_utils.py
+++ b/clinicadl/random_search/random_search_utils.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Tuple
 
 import toml
 
-from clinicadl.train.train_utils import get_user_dict
+from clinicadl.train.train_utils import build_train_dict
 from clinicadl.utils.exceptions import ClinicaDLConfigurationError
 from clinicadl.utils.preprocessing import read_preprocessing
 
@@ -54,7 +54,7 @@ def get_space_dict(launch_directory: str) -> Dict[str, Any]:
         if option not in space_dict:
             space_dict[option] = value
 
-    train_default = get_user_dict(toml_path, space_dict["network_task"])
+    train_default = build_train_dict(toml_path, space_dict["network_task"])
 
     # Mode and preprocessing
     preprocessing_json = path.join(

--- a/clinicadl/train/tasks/task_utils.py
+++ b/clinicadl/train/tasks/task_utils.py
@@ -48,10 +48,10 @@ def task_launcher(network_task: str, task_options_list: List[str], **kwargs):
                 f"in {caps_dict}."
             )
 
+    config_file_name = None
     if kwargs["config_file"]:
-        train_dict = build_train_dict(kwargs["config_file"].name, network_task)
-    else:
-        train_dict = dict()
+        config_file_name = kwargs["config_file"].name
+    train_dict = build_train_dict(config_file_name, network_task)
 
     # Mode and preprocessing
     preprocessing_dict = read_preprocessing(preprocessing_json)
@@ -93,9 +93,9 @@ def task_launcher(network_task: str, task_options_list: List[str], **kwargs):
         "compensation",
         "transfer_path",
     ]
-    standard_options_list = standard_options_list + task_options_list
+    all_options_list = standard_options_list + task_options_list
 
-    for option in standard_options_list:
+    for option in all_options_list:
         if (kwargs[option] is not None and not isinstance(kwargs[option], tuple)) or (
             isinstance(kwargs[option], tuple) and len(kwargs[option]) != 0
         ):

--- a/clinicadl/train/tasks/task_utils.py
+++ b/clinicadl/train/tasks/task_utils.py
@@ -16,7 +16,7 @@ def task_launcher(network_task: str, task_options_list: List[str], **kwargs):
         kwargs: other arguments and options for network training.
     """
     from clinicadl.train.train import train
-    from clinicadl.train.train_utils import get_user_dict
+    from clinicadl.train.train_utils import build_train_dict
 
     logger = getLogger("clinicadl")
 
@@ -49,7 +49,7 @@ def task_launcher(network_task: str, task_options_list: List[str], **kwargs):
             )
 
     if kwargs["config_file"]:
-        train_dict = get_user_dict(kwargs["config_file"].name, network_task)
+        train_dict = build_train_dict(kwargs["config_file"].name, network_task)
     else:
         train_dict = dict()
 

--- a/clinicadl/train/train_option.py
+++ b/clinicadl/train/train_option.py
@@ -88,7 +88,6 @@ label = cli_param.option_group.task_group.option(
 selection_metrics = cli_param.option_group.task_group.option(
     "--selection_metrics",
     "-sm",
-    default=["loss"],
     multiple=True,
     help="""Allow to save a list of models based on their selection metric. Default will
     only save the best model selected on loss.""",

--- a/clinicadl/train/train_utils.py
+++ b/clinicadl/train/train_utils.py
@@ -20,7 +20,25 @@ def build_train_dict(config_file: str, task: str) -> Dict[str, Any]:
     Returns:
         dictionary of values ready to use for the MapsManager
     """
-    if config_file.endswith(".toml"):
+    if config_file is None:
+        # read default values
+        clinicadl_root_dir = os.path.abspath(os.path.join(__file__, "../.."))
+        config_path = os.path.join(
+            clinicadl_root_dir,
+            "resources",
+            "config",
+            "train_config.toml",
+        )
+        config_dict = toml.load(config_path)
+        config_dict = remove_unused_tasks(config_dict, task)
+
+        train_dict = dict()
+        # Fill train_dict from TOML files arguments
+        for config_section in config_dict:
+            for key in config_dict[config_section]:
+                train_dict[key] = config_dict[config_section][key]
+
+    elif config_file.endswith(".toml"):
         user_dict = toml.load(config_file)
         if "Random_Search" in user_dict:
             del user_dict["Random_Search"]

--- a/clinicadl/train/train_utils.py
+++ b/clinicadl/train/train_utils.py
@@ -34,7 +34,7 @@ def get_user_dict(config_file: str, task: str) -> Dict[str, Any]:
             "train_config.toml",
         )
         config_dict = toml.load(config_path)
-        # Check that TOML file has the same format as the one in resources
+        # Check that TOML file has the same format as the one in clinicadl/resources/config/train_config.toml
         if toml_dict is not None:
             for section_name in toml_dict:
                 if section_name not in config_dict:
@@ -48,6 +48,7 @@ def get_user_dict(config_file: str, task: str) -> Dict[str, Any]:
                             f"{key} option in {section_name} is not valid in TOML configuration file. "
                             f"Please see the documentation to see the list of option in TOML configuration file."
                         )
+                    config_dict[section_name][key] = toml_dict[section_name][key]
 
         train_dict = dict()
 
@@ -55,10 +56,9 @@ def get_user_dict(config_file: str, task: str) -> Dict[str, Any]:
         toml_dict = remove_unused_tasks(toml_dict, task)
 
         # Standard arguments
-        for config_section in toml_dict:
-            for key in toml_dict[config_section]:
-                train_dict[key] = toml_dict[config_section][key]
-
+        for config_section in config_dict:
+            for key in config_dict[config_section]:
+                train_dict[key] = config_dict[config_section][key]
     elif config_file.endswith(".json"):
         train_dict = read_json(config_file)
     else:

--- a/clinicadl/train/train_utils.py
+++ b/clinicadl/train/train_utils.py
@@ -21,9 +21,9 @@ def build_train_dict(config_file: str, task: str) -> Dict[str, Any]:
         dictionary of values ready to use for the MapsManager
     """
     if config_file.endswith(".toml"):
-        user_config_dict = toml.load(config_file)
-        if "Random_Search" in user_config_dict:
-            del user_config_dict["Random_Search"]
+        user_dict = toml.load(config_file)
+        if "Random_Search" in user_dict:
+            del user_dict["Random_Search"]
 
         # read default values
         clinicadl_root_dir = os.path.abspath(os.path.join(__file__, "../.."))
@@ -33,34 +33,32 @@ def build_train_dict(config_file: str, task: str) -> Dict[str, Any]:
             "config",
             "train_config.toml",
         )
-        default_config_dict = toml.load(config_path)
+        config_dict = toml.load(config_path)
         # Check that TOML file has the same format as the one in clinicadl/resources/config/train_config.toml
-        if user_config_dict is not None:
-            for section_name in user_config_dict:
-                if section_name not in default_config_dict:
+        if user_dict is not None:
+            for section_name in user_dict:
+                if section_name not in config_dict:
                     raise ClinicaDLConfigurationError(
                         f"{section_name} section is not valid in TOML configuration file. "
                         f"Please see the documentation to see the list of option in TOML configuration file."
                     )
-                for key in user_config_dict[section_name]:
-                    if key not in default_config_dict[section_name]:
+                for key in user_dict[section_name]:
+                    if key not in config_dict[section_name]:
                         raise ClinicaDLConfigurationError(
                             f"{key} option in {section_name} is not valid in TOML configuration file. "
                             f"Please see the documentation to see the list of option in TOML configuration file."
                         )
-                    default_config_dict[section_name][key] = user_config_dict[
-                        section_name
-                    ][key]
+                    config_dict[section_name][key] = user_dict[section_name][key]
 
         train_dict = dict()
 
         # task dependent
-        default_config_dict = remove_unused_tasks(default_config_dict, task)
+        config_dict = remove_unused_tasks(config_dict, task)
 
         # Fill train_dict from TOML files arguments
-        for config_section in default_config_dict:
-            for key in default_config_dict[config_section]:
-                train_dict[key] = default_config_dict[config_section][key]
+        for config_section in config_dict:
+            for key in config_dict[config_section]:
+                train_dict[key] = config_dict[config_section][key]
 
     elif config_file.endswith(".json"):
         train_dict = read_json(config_file)

--- a/clinicadl/train/train_utils.py
+++ b/clinicadl/train/train_utils.py
@@ -55,7 +55,7 @@ def get_user_dict(config_file: str, task: str) -> Dict[str, Any]:
         # task dependent
         toml_dict = remove_unused_tasks(toml_dict, task)
 
-        # Standard arguments
+        # Fill train_dict from TOML files arguments
         for config_section in config_dict:
             for key in config_dict[config_section]:
                 train_dict[key] = config_dict[config_section][key]

--- a/clinicadl/train/train_utils.py
+++ b/clinicadl/train/train_utils.py
@@ -10,7 +10,7 @@ from clinicadl.utils.maps_manager.maps_manager_utils import (
 )
 
 
-def get_user_dict(config_file: str, task: str) -> Dict[str, Any]:
+def build_train_dict(config_file: str, task: str) -> Dict[str, Any]:
     """
     Read the configuration file given by the user.
     If it is a TOML file, ensures that the format corresponds to the one in resources.


### PR DESCRIPTION
This PR fixes a bug introduced in the PR #241 (commit `17fcf21`). 

The `train_dict` constructor in `clinicadl/train/train_utils.py` didn't load default argument in the TOML file in `clinicadl/resources/config/train_config.toml`.

The fact that the CI didn't "detect" this error is a problem IMO.

