### PR TITLE
Update config file for the docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,5 +18,3 @@ python:
   install:
     - method: pip
       path: ./docs/requirements.txt    
-      extra_requirements:
-        - docs

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,6 +17,6 @@ mkdocs:
 python:
   install:
     - method: pip
-      path: .    
+      path: ./docs/requirements.txt    
       extra_requirements:
         - docs

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,5 +16,4 @@ mkdocs:
 
 python:
   install:
-    - method: pip
-      path: ./docs/requirements.txt    
+    - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.9"
+    python: "3.8"
 
 mkdocs:
   configuration: mkdocs.yml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
+mkdocs:
+  configuration: mkdocs.yml
+
+python:
+  install:
+    - method: pip
+      path: .    
+      extra_requirements:
+        - docs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@
 
 mkdocs>=1.1
 mkdocs-material
+pymdown-extensions

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,7 @@ repo_url: https://github.com/aramis-lab/clinicadl
 #edit_uri: master/edit/doc
 
 # Copyright
-copyright: Copyright &copy; 2019-2021 ClinicaDL contributors
+copyright: Copyright &copy; 2019-2022 ClinicaDL contributors
 
 # Google Analytics
 google_analytics:


### PR DESCRIPTION
Manage setup for building the documentation using a config file ([see here](https://docs.readthedocs.io/en/stable/config-file/v2.html)).