### PR TITLE
Fix list_models bug

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v4.3.0
     hooks:
     -   id: check-yaml
 -   repo: https://github.com/psf/black
-    rev: 22.1.0 
+    rev: 22.6.0 
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.1.0
     hooks:
     -   id: check-yaml
 -   repo: https://github.com/psf/black
-    rev: 22.6.0 
+    rev: 22.3.0 
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/isort

--- a/clinicadl/train/list_models_cli.py
+++ b/clinicadl/train/list_models_cli.py
@@ -12,8 +12,6 @@ import click
     "-i",
     "--input_size",
     type=str,
-    default="1@128x128",
-    show_default=True,
     help="Size of the input image in the shape C@HxW if the image is 2D or C@DxHxW if the image is 3D.",
 )
 def cli(

--- a/clinicadl/train/train_utils.py
+++ b/clinicadl/train/train_utils.py
@@ -89,7 +89,7 @@ def build_train_dict(config_file: str, task: str) -> Dict[str, Any]:
     return train_dict
 
 
-def get_model_list(architecture=None, input_size=(1, 128, 128)):
+def get_model_list(architecture=None, input_size=(128, 128)):
     """
     Print the list of models available in ClinicaDL.
     If architecture is given, it prints the details of the specified model.

--- a/clinicadl/train/train_utils.py
+++ b/clinicadl/train/train_utils.py
@@ -89,7 +89,7 @@ def build_train_dict(config_file: str, task: str) -> Dict[str, Any]:
     return train_dict
 
 
-def get_model_list(architecture=None, input_size=(128, 128)):
+def get_model_list(architecture=None, input_size=(1, 128, 128)):
     """
     Print the list of models available in ClinicaDL.
     If architecture is given, it prints the details of the specified model.
@@ -119,7 +119,6 @@ def get_model_list(architecture=None, input_size=(128, 128)):
 
         # parse input_size
         chanel, shape_list = input_size.split("@")
-
         args.remove("self")
         kwargs = dict()
         kwargs["input_size"] = [int(chanel)] + [int(x) for x in shape_list.split("x")]

--- a/clinicadl/train/train_utils.py
+++ b/clinicadl/train/train_utils.py
@@ -89,7 +89,7 @@ def build_train_dict(config_file: str, task: str) -> Dict[str, Any]:
     return train_dict
 
 
-def get_model_list(architecture=None, input_size=(128, 128)):
+def get_model_list(architecture=None, input_size=None):
     """
     Print the list of models available in ClinicaDL.
     If architecture is given, it prints the details of the specified model.
@@ -116,8 +116,8 @@ def get_model_list(architecture=None, input_size=(128, 128)):
                 : model_class.__init__.__code__.co_argcount
             ]
         )
-
-        # parse input_size
+        if not input_size:
+            input_size = model_class.get_input_size()
         chanel, shape_list = input_size.split("@")
         args.remove("self")
         kwargs = dict()

--- a/clinicadl/utils/network/autoencoder/models.py
+++ b/clinicadl/utils/network/autoencoder/models.py
@@ -17,6 +17,10 @@ class AE_Conv5_FC3(AutoEncoder):
             encoder=autoencoder.encoder, decoder=autoencoder.decoder, gpu=gpu
         )
 
+    @staticmethod
+    def get_input_size():
+        return "1@128x128"
+
 
 class AE_Conv4_FC3(AutoEncoder):
     """
@@ -31,3 +35,7 @@ class AE_Conv4_FC3(AutoEncoder):
         super().__init__(
             encoder=autoencoder.encoder, decoder=autoencoder.decoder, gpu=gpu
         )
+
+    @staticmethod
+    def get_input_size():
+        return "1@128x128"

--- a/clinicadl/utils/network/cnn/models.py
+++ b/clinicadl/utils/network/cnn/models.py
@@ -80,6 +80,10 @@ class Conv5_FC3(CNN):
             gpu=gpu,
         )
 
+    @staticmethod
+    def get_input_size():
+        return "1@128x128"
+
 
 class Conv4_FC3(CNN):
     """
@@ -140,6 +144,10 @@ class Conv4_FC3(CNN):
             gpu=gpu,
         )
 
+    @staticmethod
+    def get_input_size():
+        return "1@128x128"
+
 
 class resnet18(CNN):
     def __init__(self, input_size, gpu=False, output_size=2, dropout=0.5):
@@ -169,6 +177,10 @@ class resnet18(CNN):
             n_classes=output_size,
             gpu=gpu,
         )
+
+    @staticmethod
+    def get_input_size():
+        return "3@128x128"
 
 
 class Stride_Conv5_FC3(CNN):
@@ -224,3 +236,7 @@ class Stride_Conv5_FC3(CNN):
             n_classes=output_size,
             gpu=gpu,
         )
+
+    @staticmethod
+    def get_input_size():
+        return "1@128x128"

--- a/clinicadl/utils/network/network.py
+++ b/clinicadl/utils/network/network.py
@@ -47,7 +47,11 @@ class Network(nn.Module):
 
     @staticmethod
     @abc.abstractmethod
-    def get_input_size():
+    def get_input_size() -> str:
+        """
+        This static method is used for list_models command.
+        Must return the shape of the input size expected (C@HxW or C@HxWxD) for each architecture.
+        """
         pass
 
     @abc.abstractproperty

--- a/clinicadl/utils/network/network.py
+++ b/clinicadl/utils/network/network.py
@@ -45,6 +45,11 @@ class Network(nn.Module):
                 free_gpu = argmax(memory_list)
                 return f"cuda:{free_gpu}"
 
+    @staticmethod
+    @abc.abstractmethod
+    def get_input_size():
+        pass
+
     @abc.abstractproperty
     def layers(self):
         pass

--- a/clinicadl/utils/network/sub_network.py
+++ b/clinicadl/utils/network/sub_network.py
@@ -1,3 +1,4 @@
+import abc
 from collections import OrderedDict
 from logging import getLogger
 

--- a/clinicadl/utils/network/vae/vae_utils.py
+++ b/clinicadl/utils/network/vae/vae_utils.py
@@ -18,7 +18,6 @@ class EncoderLayer2D(nn.Module):
         kernel_size=4,
         stride=2,
         padding=1,
-        output_padding=0,
     ):
         super(EncoderLayer2D, self).__init__()
         self.layer = nn.Sequential(
@@ -28,7 +27,6 @@ class EncoderLayer2D(nn.Module):
                 kernel_size,
                 stride=stride,
                 padding=padding,
-                output_padding=output_padding,
                 bias=False,
             ),
             nn.BatchNorm2d(output_channels),
@@ -329,7 +327,6 @@ class VAE_Decoder(nn.Module):
                 DecoderLayer2D(
                     last_layer_channels * 2 ** (i),
                     last_layer_channels * 2 ** (i - 1),
-                    output_padding=output_padding[i],
                 )
             )
 

--- a/clinicadl/utils/network/vae/vae_utils.py
+++ b/clinicadl/utils/network/vae/vae_utils.py
@@ -18,7 +18,6 @@ class EncoderLayer2D(nn.Module):
         kernel_size=4,
         stride=2,
         padding=1,
-        output_padding=0,
     ):
         super(EncoderLayer2D, self).__init__()
         self.layer = nn.Sequential(

--- a/clinicadl/utils/network/vae/vae_utils.py
+++ b/clinicadl/utils/network/vae/vae_utils.py
@@ -18,6 +18,7 @@ class EncoderLayer2D(nn.Module):
         kernel_size=4,
         stride=2,
         padding=1,
+        output_padding=0,
     ):
         super(EncoderLayer2D, self).__init__()
         self.layer = nn.Sequential(

--- a/clinicadl/utils/network/vae/vanilla_vae.py
+++ b/clinicadl/utils/network/vae/vanilla_vae.py
@@ -56,6 +56,10 @@ class VanillaDenseVAE(BaseVAE):
             is_3D=False,
         )
 
+    @staticmethod
+    def get_input_size():
+        return "1@128x128"
+
 
 class VanillaSpatialVAE(BaseVAE):
     def __init__(
@@ -106,6 +110,10 @@ class VanillaSpatialVAE(BaseVAE):
             KL_weight=KL_weight,
             is_3D=False,
         )
+
+    @staticmethod
+    def get_input_size():
+        return "1@128x128"
 
 
 class Vanilla3DVAE(BaseVAE):
@@ -228,6 +236,10 @@ class Vanilla3DVAE(BaseVAE):
             is_3D=False,
         )
 
+    @staticmethod
+    def get_input_size():
+        return "1@128x128x128"
+
 
 class Vanilla3DdenseVAE(BaseVAE):
     def __init__(
@@ -249,7 +261,7 @@ class Vanilla3DdenseVAE(BaseVAE):
             # [0, 0, 0],
             # [0, 0, 1],
         ]
-
+        print(input_size)
         input_c = input_size[0]
         input_d = input_size[1]
         input_h = input_size[2]
@@ -360,3 +372,7 @@ class Vanilla3DdenseVAE(BaseVAE):
             recons_weight=recons_weight,
             KL_weight=KL_weight,
         )
+
+    @staticmethod
+    def get_input_size():
+        return "1@128x128x128"

--- a/clinicadl/utils/network/vae/vanilla_vae.py
+++ b/clinicadl/utils/network/vae/vanilla_vae.py
@@ -16,10 +16,10 @@ class VanillaDenseVAE(BaseVAE):
     def __init__(
         self,
         input_size,
-        latent_space_size,
-        feature_size,
-        recons_weight,
-        KL_weight,
+        latent_space_size=128,
+        feature_size=1024,
+        recons_weight=1,
+        KL_weight=1,
         gpu=True,
     ):
         n_conv = 4
@@ -61,10 +61,10 @@ class VanillaSpatialVAE(BaseVAE):
     def __init__(
         self,
         input_size,
-        latent_space_size,
-        feature_size,
-        recons_weight,
-        KL_weight,
+        latent_space_size=128,
+        feature_size=1024,
+        recons_weight=1,
+        KL_weight=1,
         gpu=True,
     ):
         feature_channels = 64
@@ -112,10 +112,10 @@ class Vanilla3DVAE(BaseVAE):
     def __init__(
         self,
         input_size,
-        latent_space_size,
-        feature_size,
-        recons_weight,
-        KL_weight,
+        latent_space_size=256,
+        feature_size=1024,
+        recons_weight=1,
+        KL_weight=1,
         gpu=True,
     ):
         n_conv = 4

--- a/clinicadl/utils/network/vae/vanilla_vae.py
+++ b/clinicadl/utils/network/vae/vanilla_vae.py
@@ -261,7 +261,7 @@ class Vanilla3DdenseVAE(BaseVAE):
             # [0, 0, 0],
             # [0, 0, 1],
         ]
-        print(input_size)
+
         input_c = input_size[0]
         input_d = input_size[1]
         input_h = input_size[2]


### PR DESCRIPTION
Fix issue #331 

Add a static method in the Network class (get_input_size). 
Now, the command "clinicadl train list_models -a  _architecture_ " displays the network architecture even if you don't precise the input_size in the command line.

