### PR TITLE
Update documentation deployment

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,13 +7,16 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3"
 
 mkdocs:
   configuration: mkdocs.yml
 
 python:
   install:
-    - requirements: docs/requirements.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,0 @@
-################  Requirements to build the doc  ######################
-##### clinicadl doc ####
-
-mkdocs>=1.1
-mkdocs-material
-pymdown-extensions


### PR DESCRIPTION
Remove the `docs/requirements.txt` file. RDT uses now the project config file to deploy the documentation.