### PR TITLE
CI: Add workflow to publish to PyPI on release

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,20 @@
+name: publish
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: snok/install-poetry@v1
+      - name: Publish to PyPI
+        env:
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: make publish


### PR DESCRIPTION
Requires adding a GitHub secret named `POETRY_PYPI_TOKEN_PYPI`.

EDIT: Correct envvar for token