### PR TITLE
CI: Use universal publish manifest

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,19 +2,26 @@ name: publish
 
 on:
   release:
-    types:
-      - published
+    types: [ published ]
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: snok/install-poetry@v1
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Build distribution
+        run: pipx run build
       - name: Publish to PyPI
-        env:
-          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-        run: make publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
There is now a project called [build](https://pypa-build.readthedocs.io/en/stable/) which is dedicated to building Python package distributions regardless of the project backend (setuptools, poetry, hatch...).

The PyPA also publishes an official GH action for releasing to PyPI.

This PR combines both.