### PR TITLE
Maps manager check args before creating maps folder

### DIFF
--- a/clinicadl/utils/maps_manager/maps_manager.py
+++ b/clinicadl/utils/maps_manager/maps_manager.py
@@ -75,6 +75,8 @@ class MapsManager:
 
         # Initiate MAPS
         else:
+            self._check_args(parameters)
+
             if (
                 path.exists(maps_path) and not path.isdir(maps_path)  # Non-folder file
             ) or (
@@ -87,7 +89,7 @@ class MapsManager:
                 )
             makedirs(path.join(self.maps_path, "groups"))
             logger.info(f"A new MAPS was created at {maps_path}")
-            self._check_args(parameters)
+
             self.write_parameters(self.maps_path, self.parameters)
             self._write_requirements_version()
             self.split_name = "split"  # Used only for retro-compatibility


### PR DESCRIPTION
This PR allows to check if the command line arguments are correct before creating the MAPS folder.