### PR TITLE
add option --output_dir in get-labels

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3"
+    python: "3.10"
   jobs:
     post_create_environment:
       # Install Poetry

--- a/clinicadl/tsvtools/get_labels/get_labels.py
+++ b/clinicadl/tsvtools/get_labels/get_labels.py
@@ -302,7 +302,6 @@ def get_labels(
             "missing_mods": missing_mods,
             "merged_tsv": merged_tsv,
             "remove_unique_session": remove_unique_session,
-            "output_directory": results_directory,
         },
         filename="labels.json",
     )

--- a/clinicadl/tsvtools/get_labels/get_labels.py
+++ b/clinicadl/tsvtools/get_labels/get_labels.py
@@ -250,6 +250,7 @@ def get_labels(
     merged_tsv: str = None,
     missing_mods: str = None,
     remove_unique_session: bool = False,
+    output_dir: str = None,
 ):
     """
     Writes one TSV file based on merged_tsv and missing_mods.
@@ -277,11 +278,16 @@ def get_labels(
         Path to the output directory of clinica iotools check-missing-modalities if already exists
     remove_unique_session: bool
         If True, subjects with only one session are removed.
+    output_dir: str (path)
+        Path to the directory where the output labels.tsv will be stored.
     """
 
     from pathlib import Path
 
-    results_directory = Path(bids_directory).parents[0]
+    if output_dir == None:
+        results_directory = Path(bids_directory).parents[0]
+    else:
+        results_directory = output_dir
     output_tsv = results_directory / "labels.tsv"
 
     commandline_to_json(
@@ -296,6 +302,7 @@ def get_labels(
             "missing_mods": missing_mods,
             "merged_tsv": merged_tsv,
             "remove_unique_session": remove_unique_session,
+            "output_directory": results_directory,
         },
         filename="labels.json",
     )

--- a/clinicadl/tsvtools/get_labels/get_labels.py
+++ b/clinicadl/tsvtools/get_labels/get_labels.py
@@ -25,7 +25,6 @@ from clinicadl.utils.tsvtools_utils import (
     find_label,
     first_session,
     last_session,
-    merged_tsv_reader,
     neighbour_session,
 )
 

--- a/clinicadl/tsvtools/get_labels/get_labels_cli.py
+++ b/clinicadl/tsvtools/get_labels/get_labels_cli.py
@@ -42,6 +42,12 @@ from clinicadl.utils import cli_param
     default=False,
     is_flag=True,
 )
+@click.option(
+    "--output_dir",
+    help="Path to the directory where labels.tsv will be stored. ",
+    type=str,
+    default=None,
+)
 def cli(
     bids_directory,
     diagnoses,
@@ -52,6 +58,7 @@ def cli(
     missing_mods,
     merged_tsv,
     remove_unique_session,
+    output_dir,
 ):
     """Get labels in a tsv file.
 
@@ -80,6 +87,7 @@ def cli(
         missing_mods=missing_mods,
         merged_tsv=merged_tsv,
         remove_unique_session=remove_unique_session,
+        output_dir=output_dir,
     )
 
 


### PR DESCRIPTION
I added an option in `clinicadl tsvtools get-labels` in order to chose another directory to save the output if the default one is not convenient.