### PR TITLE
Fix RDT build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3"
+    python: "3.10"
   jobs:
     post_create_environment:
       # Install Poetry


### PR DESCRIPTION
Fix documentation (RTD) failing build. It forces to use python 3.10, according to clinicadl dependencies.