### PR TITLE
PyTorch Profiler

### DIFF
--- a/clinicadl/resources/config/train_config.toml
+++ b/clinicadl/resources/config/train_config.toml
@@ -38,7 +38,6 @@ gpu = true
 n_proc = 2
 batch_size = 8
 evaluation_steps = 0
-profiler = false
 
 [Reproducibility]
 seed = 0
@@ -73,3 +72,4 @@ weight_decay = 1e-4
 patience = 0
 tolerance = 0.0
 accumulation_steps = 1
+profiler = false

--- a/clinicadl/resources/config/train_config.toml
+++ b/clinicadl/resources/config/train_config.toml
@@ -38,6 +38,7 @@ gpu = true
 n_proc = 2
 batch_size = 8
 evaluation_steps = 0
+profiler = False
 
 [Reproducibility]
 seed = 0

--- a/clinicadl/resources/config/train_config.toml
+++ b/clinicadl/resources/config/train_config.toml
@@ -38,7 +38,7 @@ gpu = true
 n_proc = 2
 batch_size = 8
 evaluation_steps = 0
-profiler = False
+profiler = false
 
 [Reproducibility]
 seed = 0

--- a/clinicadl/train/tasks/classification_cli.py
+++ b/clinicadl/train/tasks/classification_cli.py
@@ -17,6 +17,7 @@ from .task_utils import task_launcher
 @train_option.n_proc
 @train_option.batch_size
 @train_option.evaluation_steps
+@train_option.profiler
 # Reproducibility
 @train_option.seed
 @train_option.deterministic

--- a/clinicadl/train/tasks/classification_cli.py
+++ b/clinicadl/train/tasks/classification_cli.py
@@ -17,7 +17,6 @@ from .task_utils import task_launcher
 @train_option.n_proc
 @train_option.batch_size
 @train_option.evaluation_steps
-@train_option.profiler
 # Reproducibility
 @train_option.seed
 @train_option.deterministic
@@ -44,6 +43,7 @@ from .task_utils import task_launcher
 @train_option.patience
 @train_option.tolerance
 @train_option.accumulation_steps
+@train_option.profiler
 # transfer learning
 @train_option.transfer_path
 @train_option.transfer_selection_metric

--- a/clinicadl/train/tasks/reconstruction_cli.py
+++ b/clinicadl/train/tasks/reconstruction_cli.py
@@ -17,6 +17,7 @@ from .task_utils import task_launcher
 @train_option.n_proc
 @train_option.batch_size
 @train_option.evaluation_steps
+@train_option.profiler
 # Reproducibility
 @train_option.seed
 @train_option.deterministic

--- a/clinicadl/train/tasks/reconstruction_cli.py
+++ b/clinicadl/train/tasks/reconstruction_cli.py
@@ -17,7 +17,6 @@ from .task_utils import task_launcher
 @train_option.n_proc
 @train_option.batch_size
 @train_option.evaluation_steps
-@train_option.profiler
 # Reproducibility
 @train_option.seed
 @train_option.deterministic
@@ -44,6 +43,7 @@ from .task_utils import task_launcher
 @train_option.patience
 @train_option.tolerance
 @train_option.accumulation_steps
+@train_option.profiler
 # transfer learning
 @train_option.transfer_path
 @train_option.transfer_selection_metric

--- a/clinicadl/train/tasks/regression_cli.py
+++ b/clinicadl/train/tasks/regression_cli.py
@@ -17,6 +17,7 @@ from .task_utils import task_launcher
 @train_option.n_proc
 @train_option.batch_size
 @train_option.evaluation_steps
+@train_option.profiler
 # Reproducibility
 @train_option.seed
 @train_option.deterministic

--- a/clinicadl/train/tasks/regression_cli.py
+++ b/clinicadl/train/tasks/regression_cli.py
@@ -17,7 +17,6 @@ from .task_utils import task_launcher
 @train_option.n_proc
 @train_option.batch_size
 @train_option.evaluation_steps
-@train_option.profiler
 # Reproducibility
 @train_option.seed
 @train_option.deterministic
@@ -44,6 +43,7 @@ from .task_utils import task_launcher
 @train_option.patience
 @train_option.tolerance
 @train_option.accumulation_steps
+@train_option.profiler
 # transfer learning
 @train_option.transfer_path
 @train_option.transfer_selection_metric

--- a/clinicadl/train/tasks/task_utils.py
+++ b/clinicadl/train/tasks/task_utils.py
@@ -51,6 +51,7 @@ def task_launcher(network_task: str, task_options_list: List[str], **kwargs):
         "normalize",
         "optimizer",
         "patience",
+        "profiler",
         "tolerance",
         "transfer_selection_metric",
         "weight_decay",

--- a/clinicadl/train/train_option.py
+++ b/clinicadl/train/train_option.py
@@ -261,7 +261,8 @@ profiler = cli_param.option_group.optimization_group.option(
     "--profiler/--no-profiler",
     type=bool,
     default=None,
-    help="Use `--profiler` to enable Pytorch profiler for the first few steps.",
+    help="Use `--profiler` to enable Pytorch profiler for the first 30 steps after a short warmup. "
+    "It will make an execution trace and some statistics about the CPU and GPU usage.",
 )
 # transfer learning
 transfer_path = cli_param.option_group.transfer_learning_group.option(

--- a/clinicadl/train/train_option.py
+++ b/clinicadl/train/train_option.py
@@ -48,7 +48,7 @@ profiler = cli_param.option_group.computational_group.option(
     "--profiler/--no-profiler",
     type=bool,
     default=None,
-    help="Use `--profiler` to enable Pytorch profiler for the first few steps."
+    help="Use `--profiler` to enable Pytorch profiler for the first few steps.",
 )
 # Reproducibility
 seed = cli_param.option_group.reproducibility_group.option(

--- a/clinicadl/train/train_option.py
+++ b/clinicadl/train/train_option.py
@@ -44,6 +44,12 @@ evaluation_steps = cli_param.option_group.computational_group.option(
     help="Fix the number of iterations to perform before computing an evaluation. Default will only "
     "perform one evaluation at the end of each epoch.",
 )
+profiler = cli_param.option_group.computational_group.option(
+    "--profiler/--no-profiler",
+    type=bool,
+    default=None,
+    help="Use `--profiler` to enable Pytorch profiler for the first few steps."
+)
 # Reproducibility
 seed = cli_param.option_group.reproducibility_group.option(
     "--seed",

--- a/clinicadl/train/train_option.py
+++ b/clinicadl/train/train_option.py
@@ -44,12 +44,6 @@ evaluation_steps = cli_param.option_group.computational_group.option(
     help="Fix the number of iterations to perform before computing an evaluation. Default will only "
     "perform one evaluation at the end of each epoch.",
 )
-profiler = cli_param.option_group.computational_group.option(
-    "--profiler/--no-profiler",
-    type=bool,
-    default=None,
-    help="Use `--profiler` to enable Pytorch profiler for the first few steps.",
-)
 # Reproducibility
 seed = cli_param.option_group.reproducibility_group.option(
     "--seed",
@@ -262,6 +256,12 @@ accumulation_steps = cli_param.option_group.optimization_group.option(
     # default=1,
     help="Accumulates gradients during the given number of iterations before performing the weight update "
     "in order to virtually increase the size of the batch.",
+)
+profiler = cli_param.option_group.optimization_group.option(
+    "--profiler/--no-profiler",
+    type=bool,
+    default=None,
+    help="Use `--profiler` to enable Pytorch profiler for the first few steps.",
 )
 # transfer learning
 transfer_path = cli_param.option_group.transfer_learning_group.option(

--- a/clinicadl/utils/maps_manager/maps_manager.py
+++ b/clinicadl/utils/maps_manager/maps_manager.py
@@ -1923,9 +1923,6 @@ class MapsManager:
 
     def _init_profiler(self):
         if self.profiler:
-            from datetime import datetime
-            from pathlib import Path
-
             from torch.profiler import (
                 ProfilerActivity,
                 profile,
@@ -1934,7 +1931,7 @@ class MapsManager:
             )
 
             time = datetime.now().strftime("%H:%M:%S")
-            filename = [Path("profiler") / f"clinicadl_{time}"]
+            filename = [self.maps_path / "profiler" / f"clinicadl_{time}"]
             # When ClinicaDL will be updated with Distributed Data Parallelism,
             # the next line will be handy, to make sure all processes write in the same file
             # dist.broadcast_object_list(filename, src=0)

--- a/clinicadl/utils/maps_manager/maps_manager.py
+++ b/clinicadl/utils/maps_manager/maps_manager.py
@@ -1934,7 +1934,7 @@ class MapsManager:
             )
 
             time = datetime.now().strftime("%H:%M:%S")
-            filename = [Path("profiler") / f"clinica_dl_{time}"]
+            filename = [Path("profiler") / f"clinicadl_{time}"]
             # When ClinicaDL will be updated with Distributed Data Parallelism,
             # the next line will be handy, to make sure all processes write in the same file
             # dist.broadcast_object_list(filename, src=0)

--- a/clinicadl/utils/maps_manager/maps_manager.py
+++ b/clinicadl/utils/maps_manager/maps_manager.py
@@ -731,6 +731,7 @@ class MapsManager:
             )
             from datetime import datetime
             from pathlib import Path
+
             time = str(datetime.now().time())[:8]
             filename = [Path("profiler") / f"clinica_dl_{time}"]
             # When ClinicaDL will be updated with Distributed Data Parallelism,
@@ -743,10 +744,11 @@ class MapsManager:
                 profile_memory=True,
                 record_shapes=False,
                 with_stack=False,
-                with_flops=False
+                with_flops=False,
             )
         else:
             from contextlib import nullcontext
+
             profiler = nullcontext()
             profiler.step = lambda *args, **kwargs: None
         return profiler

--- a/clinicadl/utils/maps_manager/maps_manager.py
+++ b/clinicadl/utils/maps_manager/maps_manager.py
@@ -723,14 +723,15 @@ class MapsManager:
 
     def _init_profiler(self):
         if self.profiler:
-            from torch.profiler import (
-                profile,
-                tensorboard_trace_handler,
-                ProfilerActivity,
-                schedule,
-            )
             from datetime import datetime
             from pathlib import Path
+
+            from torch.profiler import (
+                ProfilerActivity,
+                profile,
+                schedule,
+                tensorboard_trace_handler,
+            )
 
             time = str(datetime.now().time())[:8]
             filename = [Path("profiler") / f"clinica_dl_{time}"]

--- a/clinicadl/utils/maps_manager/maps_manager.py
+++ b/clinicadl/utils/maps_manager/maps_manager.py
@@ -1933,7 +1933,7 @@ class MapsManager:
                 tensorboard_trace_handler,
             )
 
-            time = str(datetime.now().time())[:8]
+            time = datetime.now().strftime("%H:%M:%S")
             filename = [Path("profiler") / f"clinica_dl_{time}"]
             # When ClinicaDL will be updated with Distributed Data Parallelism,
             # the next line will be handy, to make sure all processes write in the same file

--- a/clinicadl/utils/maps_manager/maps_manager.py
+++ b/clinicadl/utils/maps_manager/maps_manager.py
@@ -761,39 +761,6 @@ class MapsManager:
 
             self._erase_tmp(split)
 
-    def _init_profiler(self):
-        if self.profiler:
-            from datetime import datetime
-            from pathlib import Path
-
-            from torch.profiler import (
-                ProfilerActivity,
-                profile,
-                schedule,
-                tensorboard_trace_handler,
-            )
-
-            time = str(datetime.now().time())[:8]
-            filename = [Path("profiler") / f"clinica_dl_{time}"]
-            # When ClinicaDL will be updated with Distributed Data Parallelism,
-            # the next line will be handy, to make sure all processes write in the same file
-            # dist.broadcast_object_list(filename, src=0)
-            profiler = profile(
-                activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
-                schedule=schedule(wait=2, warmup=2, active=30, repeat=1),
-                on_trace_ready=tensorboard_trace_handler(filename[0]),
-                profile_memory=True,
-                record_shapes=False,
-                with_stack=False,
-                with_flops=False,
-            )
-        else:
-            from contextlib import nullcontext
-
-            profiler = nullcontext()
-            profiler.step = lambda *args, **kwargs: None
-        return profiler
-
     def _train(
         self,
         train_loader,
@@ -1953,6 +1920,39 @@ class MapsManager:
                 f"Task {self.network_task} is not implemented in ClinicaDL. "
                 f"Please choose between classification, regression and reconstruction."
             )
+
+    def _init_profiler(self):
+        if self.profiler:
+            from datetime import datetime
+            from pathlib import Path
+
+            from torch.profiler import (
+                ProfilerActivity,
+                profile,
+                schedule,
+                tensorboard_trace_handler,
+            )
+
+            time = str(datetime.now().time())[:8]
+            filename = [Path("profiler") / f"clinica_dl_{time}"]
+            # When ClinicaDL will be updated with Distributed Data Parallelism,
+            # the next line will be handy, to make sure all processes write in the same file
+            # dist.broadcast_object_list(filename, src=0)
+            profiler = profile(
+                activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
+                schedule=schedule(wait=2, warmup=2, active=30, repeat=1),
+                on_trace_ready=tensorboard_trace_handler(filename[0]),
+                profile_memory=True,
+                record_shapes=False,
+                with_stack=False,
+                with_flops=False,
+            )
+        else:
+            from contextlib import nullcontext
+
+            profiler = nullcontext()
+            profiler.step = lambda *args, **kwargs: None
+        return profiler
 
     ###############################
     # Getters                     #


### PR DESCRIPTION
Hi,

This new PR would add some code to allow the usage of the Pytorch profiler. This change would not help most user, but would allow ClinicaDL's dev team to evaluate changes. Some users might even use it to tune --n_proc or understand better the computational aspect of their own model.

The pytorch profiler can be buggy with some recent version of Pytorch (my tests were done with Pytorch 1.11.0, I do not know about Pytorch 2.0, but I do know that it's buggy with Pytorch 1.13). It gives you the usage of your CPU, of your GPU, the ratio of communications, GPU computations, data loading, CPU-GPU transfers, etc.

We could add other flags and parameters to tune the scheduling of the profiler, or the output filename, but I'm not sure it's worth the trouble, what do you think ?

Considering ClinicaDL is very limited by memory, enabling the profile_memory flag is probably very worth it. The 3 other flags (record_shapes, with_stacks, with_flops) are probably not necessary and might slow down the code even further without any obvious added value. Record_shapes and with_stacks might help with debugging. With_flops might help with the hardware evaluation.

With the future plan of adding Distributed Data Parallelism, I've added a commented-out line which would make sure all processes have the same filename. Because I am using the time of the execution in order not to overwrite files, there is a tiny probability that two processes have different filenames, so I'm adding a broadcast step. Maybe using the datetime is not a good idea. I can either change this naming convention, or will definitely add this line in the DDP pull request.

For people who wants to know what it looks like, I've put on Jean Zay some traces in $krk_ALL_CCFRWORK/profiler. They can be opened with Tensorboard.