### PR TITLE
fix json option bug

### DIFF
--- a/clinicadl/prepare_data/prepare_data_utils.py
+++ b/clinicadl/prepare_data/prepare_data_utils.py
@@ -62,7 +62,7 @@ def get_parameters_dict(
 def compute_extract_json(extract_json: str) -> str:
     if extract_json is None:
         return f"extract_{int(time())}.json"
-    elif not extract_json.suffix == ".json":
+    elif not extract_json.endswith(".json"):
         return f"{extract_json}.json"
     else:
         return extract_json


### PR DESCRIPTION
The "extract_json" option must be of type string because it may be specified with or without the ".json" suffix. Therefore, it cannot be treated as a Path object and so the suffix function is not applicable to a string.

Need to be included in the next release 