### PR TITLE
ensure image_path is a Path

### DIFF
--- a/clinicadl/utils/caps_dataset/data.py
+++ b/clinicadl/utils/caps_dataset/data.py
@@ -134,7 +134,7 @@ class CapsDataset(Dataset):
 
         return caps_dict
 
-    def _get_image_path(self, participant: str, session: str, cohort: str) -> str:
+    def _get_image_path(self, participant: str, session: str, cohort: str) -> Path:
         """
         Gets the path to the tensor image (*.pt)
 
@@ -174,7 +174,7 @@ class CapsDataset(Dataset):
                 [participant], [session], self.caps_dict[cohort], file_type
             )
             filepath = results[0]
-            image_path = filepath[0]
+            image_path = Path(filepath[0])
 
         return image_path
 


### PR DESCRIPTION
I have a bug in caps_dataset as it tries to apply `as_posix` in "/home/thibeaue/code/AD-DL/clinicadl/utils/caps_dataset/data.py", line 340