### PR TITLE
Filter diagnoses in split manager

### DIFF
--- a/clinicadl/utils/caps_dataset/data.py
+++ b/clinicadl/utils/caps_dataset/data.py
@@ -1055,7 +1055,7 @@ def load_data_test_single(test_path: Path, diagnoses_list, baseline=True):
             test_path = test_path.parent / "train.tsv"
 
     test_df = pd.read_csv(test_path, sep="\t")
-
+    test_df = test_df[test_df.diagnosis.isin(diagnoses_list)]
     test_df.reset_index(inplace=True, drop=True)
 
     return test_df

--- a/clinicadl/utils/split_manager/split_manager.py
+++ b/clinicadl/utils/split_manager/split_manager.py
@@ -196,6 +196,9 @@ class SplitManager:
             except:
                 pass
 
+        train_df = train_df[train_df.diagnosis.isin(cohort_diagnoses)]
+        valid_df = valid_df[valid_df.diagnosis.isin(cohort_diagnoses)]
+
         train_df.reset_index(inplace=True, drop=True)
         valid_df.reset_index(inplace=True, drop=True)
 


### PR DESCRIPTION
Right now the option `--diagnoses` is not working for me to filter diagnoses from a k-fold split when training a new network.
I could fix this problem with this PR.