### PR TITLE
Fix merged_tsv option in get_labels command

### DIFF
--- a/clinicadl/tsvtools/get_labels/get_labels.py
+++ b/clinicadl/tsvtools/get_labels/get_labels.py
@@ -319,7 +319,11 @@ def get_labels(
     # Generating the output of `clinica iotools merge-tsv `
     if merged_tsv is None:
         merged_tsv = output_dir / "merged.tsv"
-    elif not merged_tsv.is_file():
+        if merged_tsv.is_file():
+            logger.warning(
+                f"A merged_tsv file already exists at {merged_tsv}. It will be used to run the command."
+            )
+
         from clinica.iotools.utils.data_handling import create_merge_file
 
         logger.info("create merge tsv")

--- a/clinicadl/tsvtools/get_labels/get_labels.py
+++ b/clinicadl/tsvtools/get_labels/get_labels.py
@@ -307,7 +307,6 @@ def get_labels(
         missing_mods_directory = missing_mods
 
     if not missing_mods_directory.is_dir():
-
         from clinica.iotools.utils.data_handling import compute_missing_mods
 
         check_bids_folder(bids_directory)

--- a/clinicadl/tsvtools/get_labels/get_labels.py
+++ b/clinicadl/tsvtools/get_labels/get_labels.py
@@ -317,7 +317,7 @@ def get_labels(
     )
 
     # Generating the output of `clinica iotools merge-tsv `
-    if merged_tsv is None:
+    if not merged_tsv:
         merged_tsv = output_dir / "merged.tsv"
         if merged_tsv.is_file():
             logger.warning(

--- a/clinicadl/tsvtools/get_labels/get_labels.py
+++ b/clinicadl/tsvtools/get_labels/get_labels.py
@@ -326,7 +326,8 @@ def get_labels(
         else:
             from clinica.iotools.utils.data_handling import create_merge_file
 
-            logger.info("create merge tsv")
+            logger.info("Running Clinica merge TSV pipeline.")
+
             check_bids_folder(bids_directory)
             create_merge_file(
                 bids_directory,

--- a/clinicadl/tsvtools/get_labels/get_labels.py
+++ b/clinicadl/tsvtools/get_labels/get_labels.py
@@ -323,25 +323,26 @@ def get_labels(
             logger.warning(
                 f"A merged_tsv file already exists at {merged_tsv}. It will be used to run the command."
             )
+        else:
 
-        from clinica.iotools.utils.data_handling import create_merge_file
+            from clinica.iotools.utils.data_handling import create_merge_file
 
-        logger.info("create merge tsv")
-        check_bids_folder(bids_directory)
-        create_merge_file(
-            bids_directory,
-            merged_tsv,
-            caps_dir=caps_directory,
-            pipelines=None,
-            ignore_scan_files=None,
-            ignore_sessions_files=None,
-            volume_atlas_selection=None,
-            freesurfer_atlas_selection=None,
-            pvc_restriction=None,
-            tsv_file=None,
-            group_selection=False,
-            tracers_selection=False,
-        )
+            logger.info("create merge tsv")
+            check_bids_folder(bids_directory)
+            create_merge_file(
+                bids_directory,
+                merged_tsv,
+                caps_dir=caps_directory,
+                pipelines=None,
+                ignore_scan_files=None,
+                ignore_sessions_files=None,
+                volume_atlas_selection=None,
+                freesurfer_atlas_selection=None,
+                pvc_restriction=None,
+                tsv_file=None,
+                group_selection=False,
+                tracers_selection=False,
+            )
 
     logger.info(f"output of clinica iotools merge-tsv: {merged_tsv}")
 

--- a/clinicadl/tsvtools/get_labels/get_labels.py
+++ b/clinicadl/tsvtools/get_labels/get_labels.py
@@ -307,6 +307,7 @@ def get_labels(
         missing_mods_directory = missing_mods
 
     if not missing_mods_directory.is_dir():
+
         from clinica.iotools.utils.data_handling import compute_missing_mods
 
         check_bids_folder(bids_directory)

--- a/clinicadl/tsvtools/get_labels/get_labels.py
+++ b/clinicadl/tsvtools/get_labels/get_labels.py
@@ -324,7 +324,6 @@ def get_labels(
                 f"A merged_tsv file already exists at {merged_tsv}. It will be used to run the command."
             )
         else:
-
             from clinica.iotools.utils.data_handling import create_merge_file
 
             logger.info("create merge tsv")


### PR DESCRIPTION
There was a problem with the `--merged_tsv` option due to one of the last commit, the merged_tsv file was never created. 