### PR TITLE
[INFRA TEST] Add unit tests to ClinicaDL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Test
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+    branches: [dev]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test on ${{ matrix.os }} with Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+    steps:
+      - uses: actions/checkout@v3
+      - uses: snok/install-poetry@v1
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: poetry
+      - name: Run unit tests
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -86,4 +86,4 @@ install.doc: check.lock
 ## tests        : Run the unit tests
 .PHONY: test
 test: install
-	@$(POETRY) run python -m pytest -v test/unittests
+	@$(POETRY) run python -m pytest -v tests/unittests

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ help: Makefile
 	@echo "Commands:"
 	@sed -n 's/^##//p' $<
 
+.PHONY: check.lock
+check.lock:
+	@$(POETRY) lock --check
+
 ## build			: Build the package.
 .PHONY: build
 build:
@@ -16,6 +20,10 @@ build:
 .PHONY: clean.doc
 clean.doc:
 	@$(RM) -rf site
+
+.PHONY: clean.test
+clean.test:
+	@$(RM) -r .pytest_cache/
 
 ## doc			: Build the documentation.
 .PHONY: doc
@@ -61,3 +69,21 @@ lint.black: env.dev
 .PHONY: lint.isort
 lint.isort: env.dev
 	@$(POETRY) run isort --check --diff $(PACKAGES)
+
+## Install
+.PHONY: install
+install: check.lock
+	@$(POETRY) install
+
+.PHONY: install.dev
+install.dev: check.lock
+	@$(POETRY) install --only dev
+
+.PHONY: install.doc
+install.doc: check.lock
+	@$(POETRY) install --only docs
+
+## tests        : Run the unit tests
+.PHONY: test
+test: install
+	@$(POETRY) run python -m pytest -v test/unittests

--- a/clinicadl/utils/caps_dataset/data.py
+++ b/clinicadl/utils/caps_dataset/data.py
@@ -1188,7 +1188,7 @@ def load_data_test_single(test_path: Path, diagnoses_list, baseline=True):
     return test_df
 
 
-def check_multi_cohort_tsv(tsv_df, purpose):
+def check_multi_cohort_tsv(tsv_df: pd.DataFrame, purpose: str) -> None:
     """
     Checks that a multi-cohort TSV file is valid.
 
@@ -1198,11 +1198,10 @@ def check_multi_cohort_tsv(tsv_df, purpose):
     Raises:
         ValueError: if the TSV file is badly formatted.
     """
+    mandatory_col = ("cohort", "diagnoses", "path")
     if purpose.upper() == "CAPS":
-        mandatory_col = {"cohort", "path"}
-    else:
-        mandatory_col = {"cohort", "path", "diagnoses"}
-    if not mandatory_col.issubset(tsv_df.columns.values):
+        mandatory_col = ("cohort", "path")
+    if not set(mandatory_col).issubset(tsv_df.columns.values):
         raise ClinicaDLTSVError(
             f"Columns of the TSV file used for {purpose} location must include {mandatory_col}"
         )

--- a/tests/unittests/utils/caps_dataset/test_data.py
+++ b/tests/unittests/utils/caps_dataset/test_data.py
@@ -1,0 +1,51 @@
+import re
+
+import pandas as pd
+import pytest
+
+
+@pytest.mark.parametrize(
+    "dataframe_columns,purpose",
+    [
+        (["foo", "cohort", "bar", "baz", "path"], "caps"),
+        (["diagnoses", "foo", "cohort", "bar", "baz", "path"], "caps"),
+        (["diagnoses", "foo", "cohort", "bar", "baz", "path"], "foo"),
+    ],
+)
+def test_check_multi_cohort_tsv(dataframe_columns, purpose):
+    from clinicadl.utils.caps_dataset.data import check_multi_cohort_tsv
+
+    assert (
+        check_multi_cohort_tsv(pd.DataFrame(columns=dataframe_columns), purpose) is None
+    )
+
+
+@pytest.mark.parametrize(
+    "dataframe_columns,purpose,expected_mandatory_columns",
+    [
+        (
+            ["foo", "cohort", "bar", "baz", "path"],
+            "bids",
+            ("cohort", "diagnoses", "path"),
+        ),
+        (
+            ["foo", "baz", "path"],
+            "caps",
+            ("cohort", "path"),
+        ),
+    ],
+)
+def test_check_multi_cohort_tsv_errors(
+    dataframe_columns, purpose, expected_mandatory_columns
+):
+    from clinicadl.utils.caps_dataset.data import check_multi_cohort_tsv
+    from clinicadl.utils.exceptions import ClinicaDLTSVError
+
+    with pytest.raises(
+        ClinicaDLTSVError,
+        match=re.escape(
+            f"Columns of the TSV file used for {purpose} location "
+            f"must include {expected_mandatory_columns}"
+        ),
+    ):
+        check_multi_cohort_tsv(pd.DataFrame(columns=dataframe_columns), purpose)


### PR DESCRIPTION
As discussed today, this PR proposes to add unit tests to ClinicaDL.

It basically does the following:

- Add some targets to the Makefile to simplify the test workflow
- Add a test workflow to be run by GitHub actions (should run on PRs and dev branch)
- Add a unit test architecture (I picked the same as Clinica)
- Add some tests for a random function for demoing (I picked `clinicadl.utils.caps_dataset.data.check_multi_cohort_tsv` which looked relatively simple)
- Add type hints to function and simplify logic a bit
- Make the error message of the function deterministic to ease testing (sets are not ordered)