### PR TITLE
Execute SSIM on GPU

### DIFF
--- a/clinicadl/utils/metric_module.py
+++ b/clinicadl/utils/metric_module.py
@@ -50,7 +50,6 @@ class MetricModule:
         Returns:
             (Dict[str:float]) metrics results
         """
-
         if y is not None and y_pred is not None:
             results = dict()
             y = np.array(y)

--- a/clinicadl/utils/metric_module.py
+++ b/clinicadl/utils/metric_module.py
@@ -230,9 +230,9 @@ class MetricModule:
         from clinicadl.utils.pytorch_ssim import ssim, ssim3D
 
         if len(y) == 3:
-            return ssim(y, y_pred)
+            return ssim(y, y_pred).item()
         else:
-            return ssim3D(y, y_pred)
+            return ssim3D(y, y_pred).item()
 
     @staticmethod
     def psnr_fn(y, y_pred):

--- a/clinicadl/utils/pytorch_ssim.py
+++ b/clinicadl/utils/pytorch_ssim.py
@@ -164,17 +164,17 @@ class SSIM3D(torch.nn.Module):
 
 
 def ssim(y, y_pred, window_size=11, size_average=True):
-    img1 = torch.from_numpy(y)
-    img2 = torch.from_numpy(y_pred)
-    (channel, _, _) = img1.shape
+    img1 = torch.from_numpy(y)[None, ...]
+    img2 = torch.from_numpy(y_pred)[None, ...]
+    (_, channel, _, _) = img1.shape
     window = create_window(window_size, channel)
 
     if torch.cuda.is_available():
-        img1 = img1.cuda()
-        img2 = img2.cuda()
+        img1 = img1.to(device="cuda", memory_format=torch.channels_last)
+        img2 = img2.to(device="cuda", memory_format=torch.channels_last)
 
     if img1.is_cuda:
-        window = window.cuda(img1.get_device())
+        window = window.to(device=img1.device, memory_format=torch.channels_last)
     window = window.type_as(img1)
 
     return _ssim(img1, img2, window, window_size, channel, size_average)

--- a/clinicadl/utils/pytorch_ssim.py
+++ b/clinicadl/utils/pytorch_ssim.py
@@ -169,6 +169,10 @@ def ssim(y, y_pred, window_size=11, size_average=True):
     (channel, _, _) = img1.shape
     window = create_window(window_size, channel)
 
+    if torch.cuda.is_available():
+        img1 = img1.cuda()
+        img2 = img2.cuda()
+
     if img1.is_cuda:
         window = window.cuda(img1.get_device())
     window = window.type_as(img1)
@@ -181,6 +185,10 @@ def ssim3D(y, y_pred, window_size=11, size_average=True):
     img2 = torch.from_numpy(y_pred)[None, :, :, :, :]
     (_, channel, _, _, _) = img1.shape
     window = create_window_3D(window_size, channel)
+
+    if torch.cuda.is_available():
+        img1 = img1.cuda()
+        img2 = img2.cuda()
 
     if img1.is_cuda:
         window = window.cuda(img1.get_device())


### PR DESCRIPTION
Currently, during validation, we compute SSIM (at least when we are doing reconstruction). But it's always executed on CPU. With this change, each SSIM computation checks if a GPU is available and uses it, making each validation step is roughly 5x faster.