### PR TITLE
augmentation cli options

### DIFF
--- a/clinicadl/utils/cli_param/train_option.py
+++ b/clinicadl/utils/cli_param/train_option.py
@@ -18,7 +18,7 @@ config_file = click.option(
 )
 # Computational
 gpu = cli_param.option_group.computational_group.option(
-   "--gpu/--no-gpu",
+    "--gpu/--no-gpu",
     type=bool,
     default=None,
     help="Use GPU by default. Please specify `--no-gpu` to force using CPU.",
@@ -169,7 +169,21 @@ normalize = cli_param.option_group.data_group.option(
 data_augmentation = cli_param.option_group.data_group.option(
     "--data_augmentation",
     "-da",
-    type=click.Choice(["None", "Noise", "Erasing", "CropPad", "Smoothing", "Motion", "Ghosting", "Spike", "BiasField", "RandomBlur", "RandomSwap"]),
+    type=click.Choice(
+        [
+            "None",
+            "Noise",
+            "Erasing",
+            "CropPad",
+            "Smoothing",
+            "Motion",
+            "Ghosting",
+            "Spike",
+            "BiasField",
+            "RandomBlur",
+            "RandomSwap",
+        ]
+    ),
     # default=(),
     multiple=True,
     help="Randomly applies transforms on the training set.",

--- a/clinicadl/utils/cli_param/train_option.py
+++ b/clinicadl/utils/cli_param/train_option.py
@@ -18,7 +18,7 @@ config_file = click.option(
 )
 # Computational
 gpu = cli_param.option_group.computational_group.option(
-    "--gpu/--no-gpu",
+   "--gpu/--no-gpu",
     type=bool,
     default=None,
     help="Use GPU by default. Please specify `--no-gpu` to force using CPU.",
@@ -169,7 +169,7 @@ normalize = cli_param.option_group.data_group.option(
 data_augmentation = cli_param.option_group.data_group.option(
     "--data_augmentation",
     "-da",
-    type=click.Choice(["None", "Noise", "Erasing", "CropPad", "Smoothing"]),
+    type=click.Choice(["None", "Noise", "Erasing", "CropPad", "Smoothing", "Motion", "Ghosting", "Spike", "BiasField", "RandomBlur", "RandomSwap"]),
     # default=(),
     multiple=True,
     help="Randomly applies transforms on the training set.",

--- a/docs/RandomSearch.md
+++ b/docs/RandomSearch.md
@@ -93,7 +93,7 @@ Optional variables:
     - `baseline` (bool) allows to only load `_baseline.tsv` files when set to `True`.
     Sampling function: `choice`. Default: `False`.
     - `data_augmentation` (list of str) is the list of data augmentation transforms applied to the training data.
-    Must be chosen in [`None`, `Noise`, `Erasing`, `CropPad`, `Smoothing`].
+    Must be chosen in[`None`, `Noise`, `Erasing`, `CropPad`, `Smoothing`, `Motion`, `Ghosting`, `Spike`, `BiasField`, `RandomBlur`, `RandomSwap`].
     Sampling function: `fixed`. Default: `False`.
     - `unnormalize` (bool) is a flag to disable min-max normalization that is performed by default.
     Sampling function: `choice`. Default: `False`.


### PR DESCRIPTION
For ```clinicadl train classification [OPTIONS] CAPS_DIRECTORY
                                      PREPROCESSING_JSON TSV_DIRECTORY
                                      OUTPUT_MAPS_DIRECTORY```
there is a slight issue of calling augmentation methods from TorchIO I edited that part only.
at data management section for data augmentation added  
``` -da, --data_augmentation [None|Noise|Erasing|CropPad|Smoothing|Motion|Ghosting|Spike|BiasField|RandomBlur|RandomSwap]```
options.
Tested them and it's working.

