### PR TITLE
Add an option to skip data leakage check

### DIFF
--- a/clinicadl/predict/predict.py
+++ b/clinicadl/predict/predict.py
@@ -25,6 +25,7 @@ def predict(
     save_tensor: bool = False,
     save_nifti: bool = False,
     save_latent_tensor: bool = False,
+    skip_leak_check: bool = False,
 ):
     """
     This function loads a MAPS and predicts the global metrics and individual values
@@ -79,4 +80,5 @@ def predict(
         save_tensor=save_tensor,
         save_nifti=save_nifti,
         save_latent_tensor=save_latent_tensor,
+        skip_leak_check=skip_leak_check,
     )

--- a/clinicadl/predict/predict_cli.py
+++ b/clinicadl/predict/predict_cli.py
@@ -73,6 +73,13 @@ from clinicadl.utils.exceptions import ClinicaDLArgumentError
     is_flag=True,
     help="""Save the latent representation of the image.""",
 )
+@click.option(
+    "--skip_leak_check",
+    type=bool,
+    default=False,
+    is_flag=True,
+    help="Skip the data leakage check.",
+)
 @cli_param.option.split
 @cli_param.option.selection_metrics
 @cli_param.option.use_gpu
@@ -99,6 +106,7 @@ def cli(
     save_tensor,
     save_nifti,
     save_latent_tensor,
+    skip_leak_check,
 ):
     """Infer the outputs of a trained model on a test set.
 
@@ -136,4 +144,5 @@ def cli(
         save_tensor=save_tensor,
         save_nifti=save_nifti,
         save_latent_tensor=save_latent_tensor,
+        skip_leak_check=skip_leak_check,
     )

--- a/clinicadl/utils/maps_manager/maps_manager.py
+++ b/clinicadl/utils/maps_manager/maps_manager.py
@@ -212,6 +212,7 @@ class MapsManager:
         save_tensor: bool = False,
         save_nifti: bool = False,
         save_latent_tensor: bool = False,
+        skip_leak_check: bool = False,
     ):
         """
         Performs the prediction task on a subset of caps_directory defined in a TSV file.
@@ -264,6 +265,7 @@ class MapsManager:
             multi_cohort,
             overwrite,
             label=label,
+            skip_leak_check=skip_leak_check,
         )
         for split in split_list:
             logger.info(f"Prediction of split {split}")
@@ -2239,6 +2241,7 @@ class MapsManager:
         multi_cohort=False,
         overwrite=False,
         label=None,
+        skip_leak_check=False,
     ):
         """
         Check if a data group is already available if other arguments are None.
@@ -2295,7 +2298,10 @@ class MapsManager:
         elif (
             not group_dir.is_dir()
         ):  # Data group does not exist yet / was overwritten + all data is provided
-            self._check_leakage(data_group, df)
+            if skip_leak_check:
+                logger.info("Skipping data leakage check")
+            else:
+                self._check_leakage(data_group, df)
             self._write_data_group(
                 data_group, df, caps_directory, multi_cohort, label=label
             )


### PR DESCRIPTION
A function to check if there is data leakage is called in the `predict` pipeline. With this option you can skip this check so it allows prediction when you have a MAPS without the TSV files 