### PR TITLE
Solve issue: Running predict with --overwrite delete the results on all the splits

### DIFF
--- a/clinicadl/utils/maps_manager/maps_manager.py
+++ b/clinicadl/utils/maps_manager/maps_manager.py
@@ -239,11 +239,8 @@ class MapsManager:
             label: Target label used for training (if network_task in [`regression`, `classification`]).
             label_code: dictionary linking the target values to a node number.
         """
-        print(split_list)
         if not split_list:
-            print("in")
             split_list = self._find_splits()
-        print(split_list)
         logger.debug(f"List of splits {split_list}")
 
         _, all_transforms = get_transforms(

--- a/clinicadl/utils/maps_manager/maps_manager.py
+++ b/clinicadl/utils/maps_manager/maps_manager.py
@@ -238,8 +238,11 @@ class MapsManager:
             label: Target label used for training (if network_task in [`regression`, `classification`]).
             label_code: dictionary linking the target values to a node number.
         """
+        print(split_list)
         if not split_list:
+            print("in")
             split_list = self._find_splits()
+        print(split_list)
         logger.debug(f"List of splits {split_list}")
 
         _, all_transforms = get_transforms(
@@ -257,6 +260,7 @@ class MapsManager:
                 multi_cohort=multi_cohort,
             )
         criterion = self.task_manager.get_criterion(self.loss)
+
         self._check_data_group(
             data_group,
             caps_directory,
@@ -264,8 +268,10 @@ class MapsManager:
             multi_cohort,
             overwrite,
             label=label,
+            split_list=split_list,
         )
         for split in split_list:
+
             logger.info(f"Prediction of split {split}")
             group_df, group_parameters = self.get_group_info(data_group, split)
             # Find label code if not given
@@ -2239,6 +2245,7 @@ class MapsManager:
         multi_cohort=False,
         overwrite=False,
         label=None,
+        split_list=None,
     ):
         """
         Check if a data group is already available if other arguments are None.
@@ -2266,7 +2273,8 @@ class MapsManager:
                     raise MAPSError("Cannot overwrite train or validation data group.")
                 else:
                     shutil.rmtree(group_dir)
-                    split_list = self._find_splits()
+                    if not split_list:
+                        split_list = self._find_splits()
                     for split in split_list:
                         selection_metrics = self._find_selection_metrics(split)
                         for selection in selection_metrics:

--- a/clinicadl/utils/maps_manager/maps_manager.py
+++ b/clinicadl/utils/maps_manager/maps_manager.py
@@ -271,7 +271,6 @@ class MapsManager:
             split_list=split_list,
         )
         for split in split_list:
-
             logger.info(f"Prediction of split {split}")
             group_df, group_parameters = self.get_group_info(data_group, split)
             # Find label code if not given

--- a/docs/Predict.md
+++ b/docs/Predict.md
@@ -72,6 +72,7 @@ This can be useful for the `reconstruction` task, for which the user may want to
       Default will reuse the same label as in the training task.
     - `--overwrite` (bool) is a flag allowing to overwrite a data group to redefine it. All results obtained
     for this data group will be erased.
+    - `--skip_leak_check` (bool) is a flag allowing to skip the data leakage check if you don't have the TSV file from the training. This is not a good practice but sometimes, data can't be shared so this check can't be done. 
 
 ## Outputs
 


### PR DESCRIPTION
When run on a particular split, predict with the overwrite option wad deleting the results on all the splits and not only on the one chosen. 