### PR TITLE
[INFRA] Update isort in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)


### PR DESCRIPTION
Update `isort` to `5.12.0` in pre-commit config. Was getting 

```
RuntimeError: The Poetry configuration is invalid:
```

otherwise.