### PR TITLE
[INFRA] Use ruff instead of black and use codespell

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,11 +1,14 @@
 name: 'Lint codebase'
+
 on:
   pull_request:
-    branches:
-      - dev
+    branches: [ dev ]
   push:
-    branches:
-      - dev
+    branches: [ dev ]
+
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -13,13 +16,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
-      - name: Install environment
-        run: |
-          python -m ensurepip
-          python -m pip install poetry
-          make env
-      - name: Lint code with black
-        run: make lint.black
-      - name: Lint code with isort
-        run: make lint.isort
+          python-version: '3.x'
+      - uses: pre-commit/actions@v3.0.1

--- a/.jenkins/scripts/find_env.sh
+++ b/.jenkins/scripts/find_env.sh
@@ -8,7 +8,7 @@ set -e
 set +x
 
 ENV_EXISTS=0
-# Verify that the conda enviroment correponding to the branch exists, otherwise
+# Verify that the conda environment corresponding to the branch exists, otherwise
 # create it.
 ENVS=$(conda env list | awk '{print $1}' )
 echo $ENVS

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,24 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
     hooks:
-    -   id: check-yaml
--   repo: https://github.com/psf/black
-    rev: 22.6.0 
+      - id: check-yaml
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.2.2 
     hooks:
-    -   id: black
--   repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+      - id: ruff
+        args: [ --fix ]
+      - id: ruff-format
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.6
     hooks:
-      - id: isort
-        name: isort (python)
+      - id: codespell
+        additional_dependencies:
+          - tomli
+  - repo: https://github.com/python-poetry/poetry
+    rev: '1.7.1'
+    hooks:
+      - id: poetry-check
+
+default_language_version:
+  python: python3

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ clean.test:
 doc: clean.doc env.doc
 	@$(POETRY) run mkdocs build
 
-## env			: Bootstap an environment.
+## env			: Bootstrap an environment.
 .PHONY: env
 env: env.dev
 

--- a/clinicadl/generate/generate.py
+++ b/clinicadl/generate/generate.py
@@ -263,7 +263,7 @@ def generate_trivial_dataset(
 
     if mask_path is None:
         home = Path.home()
-        cache_clinicadl = home / ".cache" / "clinicadl" / "ressources" / "masks"
+        cache_clinicadl = home / ".cache" / "clinicadl" / "ressources" / "masks"  # noqa (typo in resources)
         url_aramis = "https://aramislab.paris.inria.fr/files/data/masks/"
         FILE1 = RemoteFileStructure(
             filename="AAL2.tar.gz",
@@ -574,7 +574,7 @@ def generate_hypometabolic_dataset(
         "svppa": "44f2e00bf2d2d09b532cb53e3ba61d6087b4114768cc8ae3330ea84c4b7e0e6a",
     }
     home = Path.home()
-    cache_clinicadl = home / ".cache" / "clinicadl" / "ressources" / "masks_hypo"
+    cache_clinicadl = home / ".cache" / "clinicadl" / "ressources" / "masks_hypo"  # noqa (typo in resources)
     url_aramis = "https://aramislab.paris.inria.fr/files/data/masks/hypo/"
     FILE1 = RemoteFileStructure(
         filename=f"mask_hypo_{pathology}.nii",
@@ -587,7 +587,7 @@ def generate_hypometabolic_dataset(
         # mask_path = fetch_file(FILE1, cache_clinicadl)
         try:
             mask_path = fetch_file(FILE1, cache_clinicadl)
-        except:
+        except Exception:
             DownloadError(
                 """Unable to download masks, please download them
                 manually at https://aramislab.paris.inria.fr/files/data/masks/

--- a/clinicadl/generate/generate.py
+++ b/clinicadl/generate/generate.py
@@ -3,6 +3,7 @@
 """
 This file generates data for trivial or intractable (random) data for binary classification.
 """
+
 import tarfile
 from collections import namedtuple
 from logging import getLogger

--- a/clinicadl/generate/generate_utils.py
+++ b/clinicadl/generate/generate_utils.py
@@ -59,7 +59,6 @@ def write_missing_mods(output_dir: Path, output_df: pd.DataFrame):
 def load_and_check_tsv(
     tsv_path: Path, caps_dict: Dict[str, Path], output_path: Path
 ) -> pd.DataFrame:
-
     if tsv_path is not None:
         if len(caps_dict) == 1:
             df = pd.read_csv(tsv_path, sep="\t")

--- a/clinicadl/hugging_face/hugging_face.py
+++ b/clinicadl/hugging_face/hugging_face.py
@@ -108,7 +108,7 @@ license: mit
         )
         logger.info(f"Successfully uploaded {model_name} to {maps_dir} repo in HF hub!")
 
-    except:
+    except Exception:
         from huggingface_hub import create_repo
 
         repo_name = maps_dir.name

--- a/clinicadl/prepare_data/prepare_data.py
+++ b/clinicadl/prepare_data/prepare_data.py
@@ -9,7 +9,6 @@ def DeepLearningPrepareData(
     parameters: dict,
     from_bids: str = None,
 ):
-
     from joblib import Parallel, delayed
     from torch import save as save_tensor
 

--- a/clinicadl/quality_check/t1_linear/models.py
+++ b/clinicadl/quality_check/t1_linear/models.py
@@ -328,7 +328,7 @@ class ResNet_DarqQC(nn.Module):
                 if isinstance(param, Parameter):
                     param = param.data
                 # convert to mono weight
-                # collaps parameters along second dimension, emulating grayscale feature
+                # collapse parameters along second dimension, emulating grayscale feature
                 mono_param = param.sum(1, keepdim=True)
                 if self.use_ref:
                     own_state[name].copy_(torch.cat((mono_param, mono_param), 1))
@@ -599,7 +599,7 @@ class SqueezeNetQC(nn.Module):
                 if isinstance(param, Parameter):
                     param = param.data
                 # convert to mono weight
-                # collaps parameters along second dimension, emulating grayscale feature
+                # collapse parameters along second dimension, emulating grayscale feature
                 mono_param = param.sum(1, keepdim=True)
                 if self.use_ref:
                     own_state[name].copy_(torch.cat((mono_param, mono_param), 1))

--- a/clinicadl/train/tasks/classification_cli.py
+++ b/clinicadl/train/tasks/classification_cli.py
@@ -64,7 +64,7 @@ from .task_utils import task_launcher
 @train_option.selection_metrics
 @train_option.selection_threshold
 @train_option.classification_loss
-# informations
+# information
 @train_option.emissions_calculator
 def cli(**kwargs):
     """

--- a/clinicadl/train/tasks/reconstruction_cli.py
+++ b/clinicadl/train/tasks/reconstruction_cli.py
@@ -62,7 +62,7 @@ from .task_utils import task_launcher
 # Task-related
 @train_option.selection_metrics
 @train_option.reconstruction_loss
-# informations
+# information
 @train_option.emissions_calculator
 def cli(**kwargs):
     """

--- a/clinicadl/train/tasks/regression_cli.py
+++ b/clinicadl/train/tasks/regression_cli.py
@@ -63,7 +63,7 @@ from .task_utils import task_launcher
 @train_option.label
 @train_option.selection_metrics
 @train_option.regression_loss
-# informations
+# information
 @train_option.emissions_calculator
 def cli(**kwargs):
     """

--- a/clinicadl/train/train_utils.py
+++ b/clinicadl/train/train_utils.py
@@ -145,10 +145,10 @@ def get_model_list(architecture=None, input_size=None, model_layers=False):
         )
 
         if model_layers:
-            chanel, shape_list = input_size.split("@")
+            channel, shape_list = input_size.split("@")
             args.remove("self")
             kwargs = dict()
-            kwargs["input_size"] = [int(chanel)] + [
+            kwargs["input_size"] = [int(channel)] + [
                 int(x) for x in shape_list.split("x")
             ]
             kwargs["gpu"] = False

--- a/clinicadl/tsvtools/get_labels/get_labels.py
+++ b/clinicadl/tsvtools/get_labels/get_labels.py
@@ -10,6 +10,7 @@ NB: Other preprocessing may be needed on the merged file obtained: for example t
 in the OASIS dataset is not done in this script. Moreover a quality check may be needed at the end of preprocessing
 pipelines, leading to the removal of some subjects.
 """
+
 from copy import copy
 from logging import getLogger
 from pathlib import Path
@@ -90,9 +91,9 @@ def infer_or_drop_diagnosis(bids_df: pd.DataFrame) -> pd.DataFrame:
                         ]
                     if prev_diagnosis == post_diagnosis:
                         found_diag_interpol += 1
-                        bids_copy_df.loc[(subject, session), "diagnosis"] = (
-                            prev_diagnosis
-                        )
+                        bids_copy_df.loc[
+                            (subject, session), "diagnosis"
+                        ] = prev_diagnosis
                     else:
                         bids_copy_df.drop((subject, session), inplace=True)
                         nb_drop += 1

--- a/clinicadl/tsvtools/get_progression/get_progression.py
+++ b/clinicadl/tsvtools/get_progression/get_progression.py
@@ -27,11 +27,11 @@ def get_progression(
     Parameters
     ----------
     data_tsv: str (path)
-        Path to a tsv file with columns including ["participants_id", "session_id", "dignosis"]
+        Path to a tsv file with columns including ["participants_id", "session_id", "diagnosis"]
     horizon_time: int
         Time horizon in months
     stability_dict: dict
-        Dictionnary explaining the progression of the disease. If None, it uses the Alzheimer's one : {CN: 0, MCI: 1, AD: 2}
+        Dictionary explaining the progression of the disease. If None, it uses the Alzheimer's one : {CN: 0, MCI: 1, AD: 2}
 
     """
 
@@ -56,7 +56,7 @@ def get_progression(
     bids_df.set_index(["participant_id", "session_id"], inplace=True)
     bids_df = infer_or_drop_diagnosis(bids_df)
 
-    # Check possible double change in diagnosis in time or if ther is only one session for a subject
+    # Check possible double change in diagnosis in time or if there is only one session for a subject
     # This subjects were removed in the old getlabels.
     # We can add an option to remove them, or remove them all the time or never remove them
     # We can also give two file.stv, one with unknown and unstable subjects and one without
@@ -118,7 +118,7 @@ def get_progression(
                 elif last_diagnosis_dict == diagnosis_dict:
                     update_diagnosis = "s"
 
-            # CASE 3 : if the session after 'horizon_time' months doesn't exist but ther are sessions before and after this time.
+            # CASE 3 : if the session after 'horizon_time' months doesn't exist but there are sessions before and after this time.
             else:
                 prev_session = neighbour_session(horizon_session, session_list, -1)
                 post_session = neighbour_session(horizon_session, session_list, +1)

--- a/clinicadl/tsvtools/getlabels/getlabels.py
+++ b/clinicadl/tsvtools/getlabels/getlabels.py
@@ -10,6 +10,7 @@ NB: Other preprocessing may be needed on the merged file obtained: for example t
 in the OASIS dataset is not done in this script. Moreover a quality check may be needed at the end of preprocessing
 pipelines, leading to the removal of some subjects.
 """
+
 import os
 from copy import copy
 from logging import getLogger
@@ -137,9 +138,9 @@ def infer_or_drop_diagnosis(bids_df: pd.DataFrame) -> pd.DataFrame:
                         ]
                     if prev_diagnosis == post_diagnosis:
                         found_diag_interpol += 1
-                        bids_copy_df.loc[(subject, session), "diagnosis"] = (
-                            prev_diagnosis
-                        )
+                        bids_copy_df.loc[
+                            (subject, session), "diagnosis"
+                        ] = prev_diagnosis
                     else:
                         bids_copy_df.drop((subject, session), inplace=True)
 
@@ -307,9 +308,9 @@ def mci_stability(bids_df: pd.DataFrame, horizon_time: int = 36) -> pd.DataFrame
                             update_diagnosis = stability_dict[last_diagnosis] + "MCI"
                         else:
                             update_diagnosis = "uMCI"
-                        bids_copy_df.loc[(subject, session), "diagnosis"] = (
-                            update_diagnosis
-                        )
+                        bids_copy_df.loc[
+                            (subject, session), "diagnosis"
+                        ] = update_diagnosis
 
                     else:
                         prev_session = neighbour_session(
@@ -331,9 +332,9 @@ def mci_stability(bids_df: pd.DataFrame, horizon_time: int = 36) -> pd.DataFrame
                                 update_diagnosis = "uMCI"
                             else:
                                 update_diagnosis = "sMCI"
-                        bids_copy_df.loc[(subject, session), "diagnosis"] = (
-                            update_diagnosis
-                        )
+                        bids_copy_df.loc[
+                            (subject, session), "diagnosis"
+                        ] = update_diagnosis
 
     return bids_copy_df
 

--- a/clinicadl/tsvtools/kfold/kfold.py
+++ b/clinicadl/tsvtools/kfold/kfold.py
@@ -160,7 +160,7 @@ def split_diagnoses(
                     how="inner",
                     on=["participant_id", "session_id"],
                 )
-            except:
+            except Exception:
                 raise ClinicaDLTSVError(
                     f"Your tsv file doesn't contain one of these columns : age, sex, diagnosis "
                     "and the pipeline wasn't able to find the output of clinicadl get-labels to get it."

--- a/clinicadl/tsvtools/split/split.py
+++ b/clinicadl/tsvtools/split/split.py
@@ -245,8 +245,8 @@ def split_diagnoses(
     verbose: int
         Level of verbosity.
 
-    Informations
-    ------------
+    Information
+    -----------
     writes three files per <label>.tsv file present in data_tsv:
         - data_tsv/train/<label>.tsv
         - data_tsv/train/<label>_baseline.tsv
@@ -322,7 +322,7 @@ def split_diagnoses(
                     how="inner",
                     on=["participant_id", "session_id"],
                 )
-            except:
+            except Exception:
                 raise ClinicaDLTSVError(
                     f"The column 'age', 'sex' or 'diagnosis' is missing and the pipeline was not able to find "
                     "the output of clinicadl get-labels to get it."

--- a/clinicadl/utils/cli_param/option_group.py
+++ b/clinicadl/utils/cli_param/option_group.py
@@ -24,5 +24,5 @@ task_group = OptionGroup(
 )
 informations_group = OptionGroup(
     "Informative options",
-    help=" Allow to get some more informations during the training.",
+    help=" Allow to get some more information during the training.",
 )

--- a/clinicadl/utils/cli_param/train_option.py
+++ b/clinicadl/utils/cli_param/train_option.py
@@ -244,7 +244,7 @@ preprocessing_dict_target = cli_param.option_group.data_group.option(
     "-d",
     type=str,
     default=None,
-    help="Path to json taget.",
+    help="Path to json target.",
 )
 # Cross validation
 n_splits = cli_param.option_group.cross_validation.option(
@@ -375,7 +375,7 @@ nb_unfrozen_layer = cli_param.option_group.transfer_learning_group.option(
     default=0,
     help="Number of layer that will be retrain during training. For example, if it is 2, the last two layers of the model will not be freezed.",
 )
-# informations
+# information
 emissions_calculator = cli_param.option_group.informations_group.option(
     "--calculate_emissions/--dont_calculate_emissions",
     type=bool,

--- a/clinicadl/utils/clinica_utils.py
+++ b/clinicadl/utils/clinica_utils.py
@@ -80,7 +80,6 @@ def bids_nii(
 
 
 def linear_nii(modality: str, uncropped_image: bool) -> dict:
-
     if modality not in ("T1w", "T2w", "flair"):
         raise ClinicaDLArgumentError(
             f"ClinicaDL is Unable to read this modality ({modality}) of images"
@@ -99,7 +98,7 @@ def linear_nii(modality: str, uncropped_image: bool) -> dict:
 
     information = {
         "pattern": f"*space-MNI152NLin2009cSym{desc_crop}_res-1x1x1_{modality}.nii.gz",
-        "description": f"{modality} Image registred in MNI152NLin2009cSym space using {needed_pipeline} pipeline "
+        "description": f"{modality} Image registered in MNI152NLin2009cSym space using {needed_pipeline} pipeline "
         + (
             ""
             if uncropped_image
@@ -149,7 +148,6 @@ def dwi_dti(measure: Union[str, DTIBasedMeasure], space: Optional[str] = None) -
 def pet_linear_nii(
     acq_label: str, suvr_reference_region: str, uncropped_image: bool
 ) -> dict:
-
     if uncropped_image:
         description = ""
     else:
@@ -435,7 +433,6 @@ def determine_caps_or_bids(input_dir: Path) -> bool:
 
 
 def _list_subjects_sub_folders(root_dir: Path, groups_dir: Path) -> List[Path]:
-
     warning_msg = (
         f"Could not determine if {groups_dir.parent} is a CAPS or BIDS directory. "
         "Clinica will assume this is a CAPS directory."
@@ -797,7 +794,6 @@ def _get_extension(filename: Path) -> str:
 
 
 def _get_suffix(filename: Path) -> str:
-
     return f"_{get_filename_no_ext(filename.name).split('_')[-1]}"
 
 

--- a/clinicadl/utils/maps_manager/cluster/interface.py
+++ b/clinicadl/utils/maps_manager/cluster/interface.py
@@ -174,7 +174,7 @@ class Interface(object):
         for obj_name in dir(module):
             obj = getattr(module, obj_name)
             if isclass(obj) and issubclass(obj, API) and obj is not API:
-                # obj is the class so we instanciate it
+                # obj is the class so we instantiate it
                 self.register_API(obj())
             elif isinstance(obj, API) and obj.__class__ is not API:
                 # obj is already the instance

--- a/clinicadl/utils/maps_manager/maps_manager.py
+++ b/clinicadl/utils/maps_manager/maps_manager.py
@@ -963,7 +963,7 @@ class MapsManager:
             # Create index lists for target labeled dataset
             labeled_indices = list(range(len(data_train_target_labeled)))
 
-            # Oversample the indices for the target labeld dataset to match the size of the labeled source dataset
+            # Oversample the indices for the target labelled dataset to match the size of the labeled source dataset
             data_train_source_size = len(data_train_source) // self.batch_size
             labeled_oversampled_indices = labeled_indices * (
                 data_train_source_size // len(labeled_indices)
@@ -1155,7 +1155,7 @@ class MapsManager:
                     with sync:
                         with autocast(enabled=self.amp):
                             _, loss_dict = model(data, criterion)
-                        logger.debug(f"Train loss dictionnary {loss_dict}")
+                        logger.debug(f"Train loss dictionary {loss_dict}")
                         loss = loss_dict["loss"]
                         scaler.scale(loss).backward()
 
@@ -1399,7 +1399,7 @@ class MapsManager:
                 _, _, loss_dict = model.compute_outputs_and_loss(
                     data_source, data_target, data_target_unl, criterion, alpha
                 )  # TO CHECK
-                logger.debug(f"Train loss dictionnary {loss_dict}")
+                logger.debug(f"Train loss dictionary {loss_dict}")
                 loss = loss_dict["loss"]
                 loss.backward()
                 if (i + 1) % self.accumulation_steps == 0:
@@ -1416,7 +1416,7 @@ class MapsManager:
                     ):
                         evaluation_flag = False
 
-                        # Evaluate on taget data
+                        # Evaluate on target data
                         logger.info("Evaluation on target data")
                         _, metrics_train_target = self.task_manager.test_da(
                             model,

--- a/clinicadl/utils/maps_manager/maps_manager_utils.py
+++ b/clinicadl/utils/maps_manager/maps_manager_utils.py
@@ -173,12 +173,12 @@ def remove_unused_tasks(
 
 
 def change_str_to_path(
-    toml_dict: Dict[str, Dict[str, Any]]
+    toml_dict: Dict[str, Dict[str, Any]],
 ) -> Dict[str, Dict[str, Any]]:
     """
-    For all paths in the dictionnary, it changes the type from str to pathlib.Path.
+    For all paths in the dictionary, it changes the type from str to pathlib.Path.
 
-    Paramaters
+    Parameters
     ----------
     toml_dict: Dict[str, Dict[str, Any]]
         Dictionary of options as written in a TOML file, with type(path)=str
@@ -219,12 +219,12 @@ def change_str_to_path(
 
 
 def change_path_to_str(
-    toml_dict: Dict[str, Dict[str, Any]]
+    toml_dict: Dict[str, Dict[str, Any]],
 ) -> Dict[str, Dict[str, Any]]:
     """
-    For all paths in the dictionnary, it changes the type from pathlib.Path to str.
+    For all paths in the dictionary, it changes the type from pathlib.Path to str.
 
-    Paramaters
+    Parameters
     ----------
     toml_dict: Dict[str, Dict[str, Any]]
         Dictionary of options as written in a TOML file, with type(path)=pathlib.Path
@@ -244,7 +244,7 @@ def change_path_to_str(
                     or key2.endswith("json")
                     or key2.endswith("location")
                 ):
-                    if value2 == False:
+                    if not value2:
                         toml_dict[value][key2] = ""
                     elif isinstance(value2, Path):
                         toml_dict[value][key2] = value2.as_posix()
@@ -257,7 +257,7 @@ def change_path_to_str(
                 or key.endswith("json")
                 or key.endswith("location")
             ):
-                if value == False:
+                if not value:
                     toml_dict[key] = ""
                 elif isinstance(value, Path):
                     toml_dict[key] = value.as_posix()

--- a/clinicadl/utils/network/sub_network.py
+++ b/clinicadl/utils/network/sub_network.py
@@ -124,8 +124,9 @@ class CNN(Network):
         return self.forward(x)
 
     def compute_outputs_and_loss(self, input_dict, criterion, use_labels=True):
-        images, labels = input_dict["image"].to(self.device), input_dict["label"].to(
-            self.device
+        images, labels = (
+            input_dict["image"].to(self.device),
+            input_dict["label"].to(self.device),
         )
         train_output = self.forward(images)
         if use_labels:
@@ -191,8 +192,9 @@ class CNN_SSDA(Network):
         return self.forward(x)
 
     def compute_outputs_and_loss_test(self, input_dict, criterion, alpha, target):
-        images, labels = input_dict["image"].to(self.device), input_dict["label"].to(
-            self.device
+        images, labels = (
+            input_dict["image"].to(self.device),
+            input_dict["label"].to(self.device),
         )
         train_output_source, train_output_target, _ = self.forward(images, alpha)
 

--- a/clinicadl/utils/network/vae/convolutional_VAE.py
+++ b/clinicadl/utils/network/vae/convolutional_VAE.py
@@ -1,4 +1,4 @@
-""" Credits to Benoit Sauty de Chalon @bsauty """
+"""Credits to Benoit Sauty de Chalon @bsauty"""
 
 import torch
 import torch.nn as nn

--- a/clinicadl/utils/network/vae/vae_utils.py
+++ b/clinicadl/utils/network/vae/vae_utils.py
@@ -32,7 +32,7 @@ def VAEContinuousBernoulliLoss(input, reconstruction, mu, logVar):
 def sumlogC(x, eps=1e-5):
     """
     Numerically stable implementation of
-    sum of logarithm of Continous Bernoulli
+    sum of logarithm of continuous Bernoulli
     constant C, using Taylor 2nd degree approximation
 
     Parameter

--- a/clinicadl/utils/network/vae/vanilla_vae.py
+++ b/clinicadl/utils/network/vae/vanilla_vae.py
@@ -78,7 +78,7 @@ class VanillaDenseVAE(BaseVAE):
 
 class VanillaSpatialVAE(BaseVAE):
     """
-    This network is a 3D convolutional variational autoencoder with a spacial latent space.
+    This network is a 3D convolutional variational autoencoder with a spatial latent space.
 
     reference: Diederik P Kingma et al., Auto-Encoding Variational Bayes.
     https://arxiv.org/abs/1312.6114
@@ -148,7 +148,7 @@ class VanillaSpatialVAE(BaseVAE):
 
 class Vanilla3DspacialVAE(BaseVAE):
     """
-    This network is a 3D convolutional variational autoencoder with a spacial latent space.
+    This network is a 3D convolutional variational autoencoder with a spatial latent space.
 
     reference: Diederik P Kingma et al., Auto-Encoding Variational Bayes.
     https://arxiv.org/abs/1312.6114

--- a/clinicadl/utils/split_manager/split_manager.py
+++ b/clinicadl/utils/split_manager/split_manager.py
@@ -147,8 +147,7 @@ class SplitManager:
         list_columns = train_df.columns.values
 
         if (
-            "diagnosis"
-            not in list_columns
+            "diagnosis" not in list_columns
             # or "age" not in list_columns
             # or "sex" not in list_columns
         ):
@@ -167,13 +166,12 @@ class SplitManager:
                     how="inner",
                     on=["participant_id", "session_id"],
                 )
-            except:
+            except Exception:
                 pass
 
         list_columns = valid_df.columns.values
         if (
-            "diagnosis"
-            not in list_columns
+            "diagnosis" not in list_columns
             # or "age" not in list_columns
             # or "sex" not in list_columns
         ):
@@ -192,7 +190,7 @@ class SplitManager:
                     how="inner",
                     on=["participant_id", "session_id"],
                 )
-            except:
+            except Exception:
                 pass
         train_df = train_df[
             train_df.diagnosis.isin(cohort_diagnoses)

--- a/clinicadl/utils/task_manager/classification.py
+++ b/clinicadl/utils/task_manager/classification.py
@@ -9,9 +9,6 @@ from torch.utils.data import sampler
 from torch.utils.data.distributed import DistributedSampler
 
 from clinicadl.utils.exceptions import ClinicaDLArgumentError
-
-logger = getLogger("clinicadl.task_manager")
-
 from clinicadl.utils.task_manager.task_manager import TaskManager
 
 logger = getLogger("clinicadl.task_manager")

--- a/clinicadl/utils/tracking_exp.py
+++ b/clinicadl/utils/tracking_exp.py
@@ -1,4 +1,4 @@
-"""Training Callbacks for training monitoring integrated in `pythae` (inspired from 
+"""Training Callbacks for training monitoring integrated in `pythae` (inspired from
 https://github.com/huggingface/transformers/blob/master/src/transformers/trainer_callback.py)"""
 
 import importlib

--- a/clinicadl/utils/tsvtools_utils.py
+++ b/clinicadl/utils/tsvtools_utils.py
@@ -285,7 +285,7 @@ def df_to_tsv(name: str, results_path: Path, df, baseline: bool = False) -> None
         DataFrame you want to write in a TSV file.
         Columns must include ["participant_id", "session_id"].
     baseline: bool
-        If True, ther is only baseline session for each subject.
+        If True, there is only baseline session for each subject.
     """
 
     df.sort_values(by=["participant_id", "session_id"], inplace=True)

--- a/docs/Contribute/Test.md
+++ b/docs/Contribute/Test.md
@@ -24,7 +24,7 @@ launched, in the following order:
   obtained during the **generate** test (`clinica run deeplearning-prepare-data
   ./dataset/random_example t1-linear image`) or you can [download it
   here](https://aramislab.paris.inria.fr/files/data/databases/tuto/RandomCaps.tar.gz).
-  This test verifies that the output files exist. <!--([the previoulsy trained
+  This test verifies that the output files exist. <!--([the previously trained
   models are available
   here](https://aramislab.paris.inria.fr/clinicadl/files/models/)).-->
 - **train** test (`test_train.py`): it runs training over the synthetic dataset

--- a/docs/Preprocessing/Extract.md
+++ b/docs/Preprocessing/Extract.md
@@ -31,8 +31,7 @@ which have the same arguments:
 
 ## `prepare-data-from-bids`- Extract tensors from a BIDS
 You can also extract the tensor from BIDS directory using this pipeline. In this case, you don't need to execute the [Clinica](https://aramislab.paris.inria.fr/clinica/docs/public/latest/) pipeline
-and so use unpreprocessed images with the PyTorch deep learning librairy.
-
+and so use unpreprocessed images with the PyTorch deep learning library.
 
 ## Running the pipeline
 The pipeline can be run with the following command line:

--- a/docs/TSVTools.md
+++ b/docs/TSVTools.md
@@ -185,7 +185,7 @@ Options:
 ### Output tree
 
 The command will generate a new folder `k-fold` stored in the same directory as the `DATA_TSV` file and containing the different split folders. Each of these files contains the keys (`participants_id`, `session_id`).
-For each key, it explicits which set it belongs to for each split according to the following structure (example for a 2-fold validation):
+For each key, it is expliciting which set it belongs to for each split according to the following structure (example for a 2-fold validation):
 ```
 └── 2_fold
         ├── split_0

--- a/docs/Train/Share.md
+++ b/docs/Train/Share.md
@@ -11,13 +11,13 @@ You can find the ClinicaDL organization [here](https://huggingface.co/ClinicaDL)
 
 !!! warning "Sharing limitations"
     Depending on the data, you can not be authorized to share all the MAPS, 
-    because it includes TSV files with patient informations.
+    because it includes TSV files with patient information.
 
 ## `push` - Push your MAPS to Hugging Face 
 
 ### Description
 
-This commnandline will create a new repository in Hugging face or update the repository with the given name. 
+This commandline will create a new repository in Hugging face or update the repository with the given name. 
 
 ### Running the task
 
@@ -41,7 +41,7 @@ clinicadl hugging-face push clinicadl /DATA/maps maps-test
 
 ### Description
 
-This commnandline will download a new repository from Hugging face. 
+This commandline will download a new repository from Hugging face. 
 
 ### Running the task
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,6 @@ line-ending = "auto"
 
 [tool.codespell]
 summary = ''
-skip = ".git,LICENSE.txt,*.m"
+skip = ".git,LICENSE.txt,*.m,clinicadl/resources/config/train_config.toml"
 quiet-level = 3
 ignore-words-list = "nd,fwe,commun,fo,te,artic,ressources"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,4 +101,4 @@ line-ending = "auto"
 summary = ''
 skip = ".git,LICENSE.txt,*.m"
 quiet-level = 3
-ignore-words-list = "nd,fwe,commun,fo,te,artic"
+ignore-words-list = "nd,fwe,commun,fo,te,artic,ressources"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,38 +76,29 @@ clinicadl = "clinicadl.cmdline:cli"
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.black]
+[tool.ruff]
+target-version = "py38"
 line-length = 88
-target-version = ['py36', 'py37', 'py38']
-include = '\.pyi?$'
-force-exclude = '''
-/(
-    \.eggs
-  | \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | \.pytest_cache
-  | _build
-  | buck-out
-  | build
-  | dist
-  | docs
-  | README.md
-  | MANIFEST.in
-  | LICENSE.txt
-  | clinicadl/VERSION
-)/
-'''
-exclude = '''
-/(
-    README.md
-  | MANIFEST.in
-  | LICENSE.txt
-  | clinicadl/VERSION
-)/
-'''
 
-[tool.isort]
-profile = "black"
+[tool.ruff.lint]
+select = [
+    "E",
+    "W",
+    "I",
+]
+ignore = ["E203", "E501"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["clinicadl"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+
+[tool.codespell]
+summary = ''
+skip = ".git,LICENSE.txt,*.m"
+quiet-level = 3
+ignore-words-list = "nd,fwe,commun,fo,te,artic"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,8 @@
 # coding: utf8
 
 """
-    This file contains a set of functional tests designed to check the correct execution of the pipeline and the
-    different functions available in ClinicaDL
+This file contains a set of functional tests designed to check the correct execution of the pipeline and the
+different functions available in ClinicaDL
 """
 
 import pytest

--- a/tests/test_prepare_data.py
+++ b/tests/test_prepare_data.py
@@ -101,9 +101,9 @@ def run_test_prepare_data(input_dir, ref_dir, out_dir, parameters):
                 parameters["tracer"] = acq
                 parameters["suvr_reference_region"] = "pons2"
                 parameters["use_uncropped_image"] = False
-                parameters["extract_json"] = (
-                    f"{modality}-{acq}_mode-{parameters['mode']}.json"
-                )
+                parameters[
+                    "extract_json"
+                ] = f"{modality}-{acq}_mode-{parameters['mode']}.json"
                 tsv_file = join(input_dir, f"pet_{acq}.tsv")
                 mode = parameters["mode"]
                 extract_generic(out_dir, mode, tsv_file, parameters)
@@ -111,9 +111,9 @@ def run_test_prepare_data(input_dir, ref_dir, out_dir, parameters):
         elif modality == "custom":
             parameters["save_features"] = True
             parameters["use_uncropped_image"] = True
-            parameters["custom_suffix"] = (
-                "graymatter_space-Ixi549Space_modulated-off_probability.nii.gz"
-            )
+            parameters[
+                "custom_suffix"
+            ] = "graymatter_space-Ixi549Space_modulated-off_probability.nii.gz"
             parameters["roi_custom_template"] = "Ixi549Space"
             parameters["extract_json"] = f"{modality}_mode-{parameters['mode']}.json"
             tsv_file = input_dir / "subjects.tsv"
@@ -124,9 +124,9 @@ def run_test_prepare_data(input_dir, ref_dir, out_dir, parameters):
             parameters["save_features"] = True
             for flag in uncropped_image:
                 parameters["use_uncropped_image"] = flag
-                parameters["extract_json"] = (
-                    f"{modality}_crop-{not flag}_mode-{parameters['mode']}.json"
-                )
+                parameters[
+                    "extract_json"
+                ] = f"{modality}_crop-{not flag}_mode-{parameters['mode']}.json"
 
                 # tsv_file = input_dir / "subjects.tsv"
                 mode = parameters["mode"]
@@ -137,9 +137,9 @@ def run_test_prepare_data(input_dir, ref_dir, out_dir, parameters):
             parameters["prepare_dl"] = False
             for flag in uncropped_image:
                 parameters["use_uncropped_image"] = flag
-                parameters["extract_json"] = (
-                    f"{modality}_crop-{not flag}_mode-{parameters['mode']}.json"
-                )
+                parameters[
+                    "extract_json"
+                ] = f"{modality}_crop-{not flag}_mode-{parameters['mode']}.json"
 
                 mode = f"{parameters['mode']}_flair"
                 extract_generic(out_dir, mode, None, parameters)

--- a/tests/testing_tools.py
+++ b/tests/testing_tools.py
@@ -114,7 +114,7 @@ def compare_folders(outdir: PathLike, refdir: PathLike, tmp_path: PathLike) -> b
     Compares the file hierarchy of two folders.
 
         Args:
-            outdir: path to the fisrt fodler.
+            outdir: path to the first fodler.
             refdir: path to the second folder.
             tmp_path: path to a temporary folder.
     """


### PR DESCRIPTION
This PR proposes to rely on [Ruff](https://docs.astral.sh/ruff/) rather than Black for linting.

Changes:

- modify the pre-commit hook to use Ruff (should be waaaay faster than black)
- modify the pyproject.toml to configure Ruff and Codespell (also remove previous config for black)
- modify the lint CI pipeline to rely on the pre-commit configuration
- restrict permissions to "read" for this pipeline