### PR TITLE
Solve issue when saving nifti in interpret command

### DIFF
--- a/clinicadl/utils/maps_manager/maps_manager.py
+++ b/clinicadl/utils/maps_manager/maps_manager.py
@@ -631,7 +631,7 @@ class MapsManager:
                         import nibabel as nib
                         from numpy import eye
 
-                        output_nii = nib.Nifti1Image(mode_map, eye(4))
+                        output_nii = nib.Nifti1Image(mode_map.numpy(), eye(4))
                         nib.save(
                             output_nii,
                             results_path / f"mean_{self.mode}-{i}_map.nii.gz",


### PR DESCRIPTION
Clara issue:

I’m onto the clinicaDL step that generates saliency maps from the trained model. I am following this tutorial: [https://aramislab.paris.inria.fr/clinicadl/tuto/2023/html/notebooks/interpretability.html](https://fra01.safelinks.protection.outlook.com/?url=https%3A%2F%2Faramislab.paris.inria.fr%2Fclinicadl%2Ftuto%2F2023%2Fhtml%2Fnotebooks%2Finterpretability.html&data=05%7C02%7Ccamille.brianceau%40icm-institute.org%7Ca3aa2c8338794191ac8a08dc547ca151%7C9df7cf1718fa41508b00dc5e754777d8%7C0%7C0%7C638478141461123925%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C0%7C%7C%7C&sdata=2yCQtquQvlxMs0EQ8pnYT8nm9lbNJtxWJDrvYHT28tA%3D&reserved=0)
 
However, when I run this step:
# grad-cam diagnosis AD
clinicadl interpret interpret/maps_trivial test-gc gc_AD grad-cam -d AD --caps_directory interpret/caps_trivial_tensor --participants_tsv interpret/caps_trivial_tensor/data.tsv
 
It only outputs the *.pt files, but not the * map.nii.gz files mentioned in the tutorial.
 
I then ran the same code with the “--save_nifti” option added:
clinicadl interpret interpret/maps_trivial test-gc2 gc_AD grad-cam -d AD --caps_directory interpret/caps_trivial_tensor --participants_tsv interpret/caps_trivial_tensor/data.tsv  --save_nifti
 
And this gives me an error:
Traceback (most recent call last):                                                                                                                     
  File "/home/uqjjian3/.local/lib/python3.8/site-packages/nibabel/analyze.py", line 569, in set_data_dtype                                             
    dt = np.dtype(dt)                                                                                                                                  
TypeError: Cannot interpret 'torch.float32' as a data type