### PR TITLE
BUG in CI tests for prepare_data

### DIFF
--- a/tests/test_prepare_data.py
+++ b/tests/test_prepare_data.py
@@ -147,7 +147,9 @@ def run_test_prepare_data(input_dir, ref_dir, out_dir, parameters):
             raise NotImplementedError(
                 f"Test for modality {modality} was not implemented."
             )
-    assert compare_folders(out_dir / f"caps_{mode}", ref_dir / f"caps_{mode}", out_dir)
+        assert compare_folders(
+            out_dir / f"caps_{mode}", ref_dir / f"caps_{mode}", out_dir
+        )
 
 
 def extract_generic(out_dir, mode, tsv_file, parameters):


### PR DESCRIPTION
compare folder function wasn't well indented in the test_prepare_data.py file so we missed some bug 