### PR TITLE
[CI] Run tests through GitHub Actions

### DIFF
--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -32,7 +32,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          cache: poetry
       - name: Run CLI tests
         run: |
           make env.conda

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -1,0 +1,46 @@
+name: CLI Tests
+
+on:
+  push:
+    branches: ["dev"]
+  pull_request:
+    branches: ["dev"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+env:
+  POETRY_VERSION: '1.6.1'
+  PYTHON_VERSION: '3.11'
+
+jobs:
+  test-cli:
+    runs-on:
+      - self-hosted
+      - Linux
+    steps:
+      - uses: actions/checkout@v4
+      - uses: snok/install-poetry@v1
+        with:
+          version: ${{ env.POETRY_VERSION }}
+          virtualenvs-create: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: poetry
+      - name: Run instantiation tests
+        run: |
+          make env.conda
+          source /builds/miniconda/etc/profile.d/conda.sh
+          conda activate "${{ github.workspace }}"/env
+          make install
+          cd tests
+          poetry run pytest --verbose \
+          --junitxml=./test-reports/test_cli_report.xml \
+          --disable-warnings \
+          --verbose \
+          test_cli.py

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on:
       - self-hosted
       - Linux
+      - ubuntu
     steps:
       - uses: actions/checkout@v4
       - uses: snok/install-poetry@v1

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -33,10 +33,10 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: poetry
-      - name: Run instantiation tests
+      - name: Run CLI tests
         run: |
           make env.conda
-          source /builds/miniconda/etc/profile.d/conda.sh
+          source /builds/miniconda3/etc/profile.d/conda.sh
           conda activate "${{ github.workspace }}"/env
           make install
           cd tests

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  POETRY_VERSION: '1.6.1'
+  POETRY_VERSION: '1.8.3'
   PYTHON_VERSION: '3.11'
 
 jobs:

--- a/.github/workflows/test_tsvtools.yml
+++ b/.github/workflows/test_tsvtools.yml
@@ -1,0 +1,48 @@
+name: TSV Tools Tests
+
+on:
+  push:
+    branches: ["dev"]
+  pull_request:
+    branches: ["dev"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+env:
+  POETRY_VERSION: '1.8.3'
+  PYTHON_VERSION: '3.11'
+
+jobs:
+  test-tsvtools:
+    runs-on:
+      - self-hosted
+      - Linux
+      - ubuntu
+    steps:
+      - uses: actions/checkout@v4
+      - uses: snok/install-poetry@v1
+        with:
+          version: ${{ env.POETRY_VERSION }}
+          virtualenvs-create: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Run tests for TSV tools
+        run: |
+          make env.conda
+          source /builds/miniconda3/etc/profile.d/conda.sh
+          conda activate "${{ github.workspace }}"/env
+          make install
+          cd tests
+          poetry run pytest --verbose \
+          --junitxml=./test-reports/test_tsvtools_report.xml \
+          --disable-warnings \
+          --verbose \
+          --basetemp=$HOME/tmp \
+          --input_data_directory=/mnt/data/data_ci \
+          test_tsvtools.py


### PR DESCRIPTION
This PR proposes to run the tests through GitHub Actions rather than Jenkins (similar to what we did on Clinica a few months ago).

The VM that was used until now is running on CentOS7 and was clearly missing recent updates.
In addition, CentOS7 will be EOL in June 2024 (https://endoflife.date/centos).
Because of these reasons, I created and configured a new VM running on Ubuntu 20.04-lts.
I should have installed the required tools that we use (like dvc, pipx, poetry, miniconda...) but let me know if something is missing.

I also deployed a new GitHub runner on this VM (there is also one deployed on the CentOS VM but the workflows are crashing due to an old version of glibc, I'll delete it later).

This PR proposes to port two tests: `test_cli.py` and `test_tsvtools.py` to Github Actions, making sure that tests with and without access to `clinical_data_ci` are working fine.

If the proposed solution is accepted, I'll port the remaining tests and remove the associated Jenkins pipeline.

I will also need to take a closer look at the machine were are using for testing GPU support to see if we could implement something similar.