### PR TITLE
[CI] Port remaining non GPU tests to GitHub Actions

### DIFF
--- a/.github/workflows/test_generate.yml
+++ b/.github/workflows/test_generate.yml
@@ -1,0 +1,51 @@
+name: Generate Tests
+
+on:
+  push:
+    branches: ["dev"]
+  pull_request:
+    branches: ["dev"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+env:
+  POETRY_VERSION: '1.8.3'
+  PYTHON_VERSION: '3.11'
+
+jobs:
+  test-generate:
+    runs-on:
+      - self-hosted
+      - Linux
+      - ubuntu
+    steps:
+      - uses: actions/checkout@v4
+      - uses: snok/install-poetry@v1
+        with:
+          version: ${{ env.POETRY_VERSION }}
+          virtualenvs-create: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Run tests for generate task
+        run: |
+          make env.conda
+          source /builds/miniconda3/etc/profile.d/conda.sh
+          conda activate "${{ github.workspace }}"/env
+          make install
+          cd tests
+          poetry run pytest --verbose \
+          --junitxml=./test-reports/test_generate_report.xml \
+          --disable-warnings \
+          --verbose \
+          --basetemp=$HOME/tmp/generate \
+          --input_data_directory=/mnt/data/data_ci \
+          test_generate.py
+      - name: Cleaning
+        run: |
+          rm -rf $HOME/tmp/generate

--- a/.github/workflows/test_generate.yml
+++ b/.github/workflows/test_generate.yml
@@ -2,9 +2,9 @@ name: Generate Tests
 
 on:
   push:
-    branches: ["dev"]
+    branches: ["dev", "refactoring"]
   pull_request:
-    branches: ["dev"]
+    branches: ["dev", "refactoring"]
 
 permissions:
   contents: read
@@ -19,10 +19,12 @@ env:
 
 jobs:
   test-generate:
+    if: github.event.pull_request.draft == false
     runs-on:
       - self-hosted
       - Linux
       - ubuntu
+      - cpu
     steps:
       - uses: actions/checkout@v4
       - uses: snok/install-poetry@v1

--- a/.github/workflows/test_predict.yml
+++ b/.github/workflows/test_predict.yml
@@ -2,9 +2,9 @@ name: Predict Tests
 
 on:
   push:
-    branches: ["dev"]
+    branches: ["dev", "refactoring"]
   pull_request:
-    branches: ["dev"]
+    branches: ["dev", "refactoring"]
 
 permissions:
   contents: read
@@ -19,10 +19,12 @@ env:
 
 jobs:
   test-predict:
+    if: github.event.pull_request.draft == false
     runs-on:
       - self-hosted
       - Linux
       - ubuntu
+      - cpu
     steps:
       - uses: actions/checkout@v4
       - uses: snok/install-poetry@v1

--- a/.github/workflows/test_predict.yml
+++ b/.github/workflows/test_predict.yml
@@ -1,0 +1,51 @@
+name: Predict Tests
+
+on:
+  push:
+    branches: ["dev"]
+  pull_request:
+    branches: ["dev"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+env:
+  POETRY_VERSION: '1.8.3'
+  PYTHON_VERSION: '3.11'
+
+jobs:
+  test-predict:
+    runs-on:
+      - self-hosted
+      - Linux
+      - ubuntu
+    steps:
+      - uses: actions/checkout@v4
+      - uses: snok/install-poetry@v1
+        with:
+          version: ${{ env.POETRY_VERSION }}
+          virtualenvs-create: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Run tests for predict task
+        run: |
+          make env.conda
+          source /builds/miniconda3/etc/profile.d/conda.sh
+          conda activate "${{ github.workspace }}"/env
+          make install
+          cd tests
+          poetry run pytest --verbose \
+          --junitxml=./test-reports/test_predict_report.xml \
+          --disable-warnings \
+          --verbose \
+          --basetemp=$HOME/tmp/predict \
+          --input_data_directory=/mnt/data/data_ci \
+          test_predict.py
+      - name: Cleaning
+        run: |
+          rm -rf $HOME/tmp/predict/*

--- a/.github/workflows/test_prepare_data.yml
+++ b/.github/workflows/test_prepare_data.yml
@@ -2,9 +2,9 @@ name: Prepare data Tests
 
 on:
   push:
-    branches: ["dev"]
+    branches: ["dev", "refactoring"]
   pull_request:
-    branches: ["dev"]
+    branches: ["dev", "refactoring"]
 
 permissions:
   contents: read
@@ -19,10 +19,12 @@ env:
 
 jobs:
   test-prepare-data:
+    if: github.event.pull_request.draft == false
     runs-on:
       - self-hosted
       - Linux
       - ubuntu
+      - cpu
     steps:
       - uses: actions/checkout@v4
       - uses: snok/install-poetry@v1

--- a/.github/workflows/test_prepare_data.yml
+++ b/.github/workflows/test_prepare_data.yml
@@ -1,0 +1,51 @@
+name: Prepare data Tests
+
+on:
+  push:
+    branches: ["dev"]
+  pull_request:
+    branches: ["dev"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+env:
+  POETRY_VERSION: '1.8.3'
+  PYTHON_VERSION: '3.11'
+
+jobs:
+  test-prepare-data:
+    runs-on:
+      - self-hosted
+      - Linux
+      - ubuntu
+    steps:
+      - uses: actions/checkout@v4
+      - uses: snok/install-poetry@v1
+        with:
+          version: ${{ env.POETRY_VERSION }}
+          virtualenvs-create: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Run tests for prepare data task
+        run: |
+          make env.conda
+          source /builds/miniconda3/etc/profile.d/conda.sh
+          conda activate "${{ github.workspace }}"/env
+          make install
+          cd tests
+          poetry run pytest --verbose \
+          --junitxml=./test-reports/test_prepare_data_report.xml \
+          --disable-warnings \
+          --verbose \
+          --basetemp=$HOME/tmp/prepare_data \
+          --input_data_directory=/mnt/data/data_ci \
+          test_prepare_data.py
+      - name: Cleaning
+        run: |
+          rm -rf $HOME/tmp/prepare_data/*

--- a/.github/workflows/test_quality_checks.yml
+++ b/.github/workflows/test_quality_checks.yml
@@ -2,9 +2,9 @@ name: Quality Check Tests
 
 on:
   push:
-    branches: ["dev"]
+    branches: ["dev", "refactoring"]
   pull_request:
-    branches: ["dev"]
+    branches: ["dev", "refactoring"]
 
 permissions:
   contents: read
@@ -19,10 +19,12 @@ env:
 
 jobs:
   test-quality-check:
+    if: github.event.pull_request.draft == false
     runs-on:
       - self-hosted
       - Linux
       - ubuntu
+      - cpu
     steps:
       - uses: actions/checkout@v4
       - uses: snok/install-poetry@v1

--- a/.github/workflows/test_quality_checks.yml
+++ b/.github/workflows/test_quality_checks.yml
@@ -1,0 +1,51 @@
+name: Quality Check Tests
+
+on:
+  push:
+    branches: ["dev"]
+  pull_request:
+    branches: ["dev"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+env:
+  POETRY_VERSION: '1.8.3'
+  PYTHON_VERSION: '3.11'
+
+jobs:
+  test-quality-check:
+    runs-on:
+      - self-hosted
+      - Linux
+      - ubuntu
+    steps:
+      - uses: actions/checkout@v4
+      - uses: snok/install-poetry@v1
+        with:
+          version: ${{ env.POETRY_VERSION }}
+          virtualenvs-create: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Run tests for Quality Check
+        run: |
+          make env.conda
+          source /builds/miniconda3/etc/profile.d/conda.sh
+          conda activate "${{ github.workspace }}"/env
+          make install
+          cd tests
+          poetry run pytest --verbose \
+          --junitxml=./test-reports/test_quality_check_report.xml \
+          --disable-warnings \
+          --verbose \
+          --basetemp=$HOME/tmp/quality_checks \
+          --input_data_directory=/mnt/data/data_ci \
+          test_qc.py
+      - name: Cleaning
+        run: |
+          rm -rf $HOME/tmp/quality_checks/*

--- a/.github/workflows/test_tsvtools.yml
+++ b/.github/workflows/test_tsvtools.yml
@@ -45,6 +45,9 @@ jobs:
           --junitxml=./test-reports/test_tsvtools_report.xml \
           --disable-warnings \
           --verbose \
-          --basetemp=$HOME/tmp \
+          --basetemp=$HOME/tmp/tsv_tools \
           --input_data_directory=/mnt/data/data_ci \
           test_tsvtools.py
+      - name: Cleaning
+        run: |
+          rm -rf $HOME/tmp/tsv_tools/*


### PR DESCRIPTION
Following #573 this PR proposes to port the remaining tests of the non-GPU Jenkins pipeline to Github Actions.
I kept the Jenkins file as is and will remove the pipeline in a follow-up PR if all went well.