### PR TITLE
[CI] Test train workflow on GPU machine

### DIFF
--- a/.github/workflows/test_train.yml
+++ b/.github/workflows/test_train.yml
@@ -2,9 +2,9 @@ name: Train Tests (GPU)
 
 on:
   push:
-    branches: ["dev"]
+    branches: ["dev", "refactoring"]
   pull_request:
-    branches: ["dev"]
+    branches: ["dev", "refactoring"]
 
 permissions:
   contents: read

--- a/.github/workflows/test_train.yml
+++ b/.github/workflows/test_train.yml
@@ -19,6 +19,7 @@ env:
 
 jobs:
   test-train-gpu:
+    if: github.event.pull_request.draft == false
     runs-on:
       - self-hosted
       - Linux

--- a/.github/workflows/test_train.yml
+++ b/.github/workflows/test_train.yml
@@ -44,9 +44,9 @@ jobs:
           --junitxml=./test-reports/test_train_report.xml \
           --disable-warnings \
           --verbose \
-          --basetemp=$HOME/tmp/train \
+          --basetemp=$HOME/actions_runner_workdir/train \
           --input_data_directory=/mnt/data/clinicadl_data_ci/data_ci \
           -k test_train
       - name: Cleaning
         run: |
-          rm -rf $HOME/tmp/train/*
+          rm -rf $HOME/actions_runner_workdir/train/*

--- a/.github/workflows/test_train.yml
+++ b/.github/workflows/test_train.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run tests for Train on GPU
         run: |
           make env.conda
-          source /builds/miniconda3/etc/profile.d/conda.sh
+          source "${HOME}/miniconda3/etc/profile.d/conda.sh"
           conda activate "${{ github.workspace }}"/env
           make install
           cd tests

--- a/.github/workflows/test_train.yml
+++ b/.github/workflows/test_train.yml
@@ -1,0 +1,52 @@
+name: Train Tests (GPU)
+
+on:
+  push:
+    branches: ["dev"]
+  pull_request:
+    branches: ["dev"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+env:
+  POETRY_VERSION: '1.8.3'
+  PYTHON_VERSION: '3.11'
+
+jobs:
+  test-train-gpu:
+    runs-on:
+      - self-hosted
+      - Linux
+      - ubuntu
+      - gpu
+    steps:
+      - uses: actions/checkout@v4
+      - uses: snok/install-poetry@v1
+        with:
+          version: ${{ env.POETRY_VERSION }}
+          virtualenvs-create: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Run tests for Train on GPU
+        run: |
+          make env.conda
+          source /builds/miniconda3/etc/profile.d/conda.sh
+          conda activate "${{ github.workspace }}"/env
+          make install
+          cd tests
+          poetry run pytest --verbose \
+          --junitxml=./test-reports/test_train_report.xml \
+          --disable-warnings \
+          --verbose \
+          --basetemp=$HOME/tmp/train \
+          --input_data_directory=/mnt/data/clinicadl_data_ci/data_ci \
+          -k test_train
+      - name: Cleaning
+        run: |
+          rm -rf $HOME/tmp/train/*


### PR DESCRIPTION
Try to execute the "train" tests on the GPU machine Garonne through GitHub Actions rather than Jenkins.

Related PRs: #573 and #581