### PR TITLE
[CI] Port remaining GPU tests to GitHub Actions

### DIFF
--- a/.github/workflows/test_interpret.yml
+++ b/.github/workflows/test_interpret.yml
@@ -1,0 +1,53 @@
+name: Interpretation Tests (GPU)
+
+on:
+  push:
+    branches: ["dev", "refactoring"]
+  pull_request:
+    branches: ["dev", "refactoring"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+env:
+  POETRY_VERSION: '1.8.3'
+  PYTHON_VERSION: '3.11'
+
+jobs:
+  test-interpret-gpu:
+    if: github.event.pull_request.draft == false
+    runs-on:
+      - self-hosted
+      - Linux
+      - ubuntu
+      - gpu
+    steps:
+      - uses: actions/checkout@v4
+      - uses: snok/install-poetry@v1
+        with:
+          version: ${{ env.POETRY_VERSION }}
+          virtualenvs-create: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Run tests for Interpret task on GPU
+        run: |
+          make env.conda
+          source "${HOME}/miniconda3/etc/profile.d/conda.sh"
+          conda activate "${{ github.workspace }}"/env
+          make install
+          cd tests
+          poetry run pytest --verbose \
+          --junitxml=./test-reports/test_interpret_report.xml \
+          --disable-warnings \
+          --verbose \
+          --basetemp=$HOME/actions_runner_workdir/interpret \
+          --input_data_directory=/mnt/data/clinicadl_data_ci/data_ci \
+          test_interpret.py
+      - name: Cleaning
+        run: |
+          rm -rf $HOME/actions_runner_workdir/interpret/*

--- a/.github/workflows/test_random_search.yml
+++ b/.github/workflows/test_random_search.yml
@@ -1,0 +1,53 @@
+name: Random Search Tests (GPU)
+
+on:
+  push:
+    branches: ["dev", "refactoring"]
+  pull_request:
+    branches: ["dev", "refactoring"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+env:
+  POETRY_VERSION: '1.8.3'
+  PYTHON_VERSION: '3.11'
+
+jobs:
+  test-random-search-gpu:
+    if: github.event.pull_request.draft == false
+    runs-on:
+      - self-hosted
+      - Linux
+      - ubuntu
+      - gpu
+    steps:
+      - uses: actions/checkout@v4
+      - uses: snok/install-poetry@v1
+        with:
+          version: ${{ env.POETRY_VERSION }}
+          virtualenvs-create: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Run Random Search tests on GPU
+        run: |
+          make env.conda
+          source "${HOME}/miniconda3/etc/profile.d/conda.sh"
+          conda activate "${{ github.workspace }}"/env
+          make install
+          cd tests
+          poetry run pytest --verbose \
+          --junitxml=./test-reports/test_random_search_report.xml \
+          --disable-warnings \
+          --verbose \
+          --basetemp=$HOME/actions_runner_workdir/random_search \
+          --input_data_directory=/mnt/data/clinicadl_data_ci/data_ci \
+          test_random_search.py
+      - name: Cleaning
+        run: |
+          rm -rf $HOME/actions_runner_workdir/random_search/*

--- a/.github/workflows/test_resume.yml
+++ b/.github/workflows/test_resume.yml
@@ -1,0 +1,53 @@
+name: Resume Tests (GPU)
+
+on:
+  push:
+    branches: ["dev", "refactoring"]
+  pull_request:
+    branches: ["dev", "refactoring"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+env:
+  POETRY_VERSION: '1.8.3'
+  PYTHON_VERSION: '3.11'
+
+jobs:
+  test-resume-gpu:
+    if: github.event.pull_request.draft == false
+    runs-on:
+      - self-hosted
+      - Linux
+      - ubuntu
+      - gpu
+    steps:
+      - uses: actions/checkout@v4
+      - uses: snok/install-poetry@v1
+        with:
+          version: ${{ env.POETRY_VERSION }}
+          virtualenvs-create: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Run resume tests on GPU
+        run: |
+          make env.conda
+          source "${HOME}/miniconda3/etc/profile.d/conda.sh"
+          conda activate "${{ github.workspace }}"/env
+          make install
+          cd tests
+          poetry run pytest --verbose \
+          --junitxml=./test-reports/test_resume_report.xml \
+          --disable-warnings \
+          --verbose \
+          --basetemp=$HOME/actions_runner_workdir/resume \
+          --input_data_directory=/mnt/data/clinicadl_data_ci/data_ci \
+          test_resume.py
+      - name: Cleaning
+        run: |
+          rm -rf $HOME/actions_runner_workdir/resume/*

--- a/.github/workflows/test_transfer_learning.yml
+++ b/.github/workflows/test_transfer_learning.yml
@@ -1,0 +1,53 @@
+name: Transfer Learning Tests (GPU)
+
+on:
+  push:
+    branches: ["dev", "refactoring"]
+  pull_request:
+    branches: ["dev", "refactoring"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+env:
+  POETRY_VERSION: '1.8.3'
+  PYTHON_VERSION: '3.11'
+
+jobs:
+  test-transfer-learning-gpu:
+    if: github.event.pull_request.draft == false
+    runs-on:
+      - self-hosted
+      - Linux
+      - ubuntu
+      - gpu
+    steps:
+      - uses: actions/checkout@v4
+      - uses: snok/install-poetry@v1
+        with:
+          version: ${{ env.POETRY_VERSION }}
+          virtualenvs-create: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Run tests for Transfer Learning on GPU
+        run: |
+          make env.conda
+          source "${HOME}/miniconda3/etc/profile.d/conda.sh"
+          conda activate "${{ github.workspace }}"/env
+          make install
+          cd tests
+          poetry run pytest --verbose \
+          --junitxml=./test-reports/test_transfer_learning_report.xml \
+          --disable-warnings \
+          --verbose \
+          --basetemp=$HOME/actions_runner_workdir/transfer_learning \
+          --input_data_directory=/mnt/data/clinicadl_data_ci/data_ci \
+          test_transfer_learning.py
+      - name: Cleaning
+        run: |
+          rm -rf $HOME/actions_runner_workdir/transfer_learning/*


### PR DESCRIPTION
Following #590 this PR proposes to port the remaining GPU tests to GitHub Actions.

If everything goes well, I'll take care of deleting the GPU Jenkins pipeline in a follow-up PR.