### PR TITLE
Add flags to run CI tests locally

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,20 +15,21 @@ def pytest_addoption(parser):
         help="Directory for (only-read) inputs for tests",
     )
     parser.addoption(
-        "--simulate-gpu",
+        "--no-gpu",
         action="store_true",
-        help="""To simulate the presence of a gpu on a cpu-only device. Default is False.
+        help="""To run tests on cpu. Default is False.
             To use carefully, only to run tests locally. Should not be used in final CI tests.
-            Concretely, the tests won't fail if gpu option if false in the output MAPS whereas
-            it should be true.""",
+            Concretely, the tests won't fail if gpu option is false in the output MAPS whereas
+            it is true in the reference MAPS.""",
     )
     parser.addoption(
         "--adapt-base-dir",
         action="store_true",
-        help="""To virtually change the base directory in the paths stored in MAPS. Default is False.
+        help="""To virtually change the base directory in the paths stored in the MAPS of the CI data.
+            Default is False.
             To use carefully, only to run tests locally. Should not be used in final CI tests.
-            Concretely, the tests won't fail if only the base directory differs in the paths stored
-            in the MAPS.""",
+            Concretely, the tests won't fail if only the base directories differ in the paths stored
+            in the output and reference MAPS.""",
     )
 
 
@@ -36,6 +37,6 @@ def pytest_addoption(parser):
 def cmdopt(request):
     config_param = {}
     config_param["input"] = request.config.getoption("--input_data_directory")
-    config_param["simulate gpu"] = request.config.getoption("--simulate-gpu")
-    config_param["adapt base dir"] = request.config.getoption("--adapt-base-dir")
+    config_param["no-gpu"] = request.config.getoption("--no-gpu")
+    config_param["adapt-base-dir"] = request.config.getoption("--adapt-base-dir")
     return config_param

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,10 +14,19 @@ def pytest_addoption(parser):
         action="store",
         help="Directory for (only-read) inputs for tests",
     )
+    parser.addoption(
+        "--simulate-gpu",
+        action="store_true",
+        help="""To simulate the presence of a gpu on a cpu-only device. Default is False.
+            To use carefully, only to run tests locally. Should not be used in final CI tests.
+            Concretely, the tests won't fail if gpu option if false in the output MAPS whereas
+            it should be true.""",
+    )
 
 
 @pytest.fixture
 def cmdopt(request):
     config_param = {}
     config_param["input"] = request.config.getoption("--input_data_directory")
+    config_param["simulate gpu"] = request.config.getoption("--simulate-gpu")
     return config_param

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,14 @@ def pytest_addoption(parser):
             Concretely, the tests won't fail if gpu option if false in the output MAPS whereas
             it should be true.""",
     )
+    parser.addoption(
+        "--adapt-base-dir",
+        action="store_true",
+        help="""To virtually change the base directory in the paths stored in MAPS. Default is False.
+            To use carefully, only to run tests locally. Should not be used in final CI tests.
+            Concretely, the tests won't fail if only the base directory differs in the paths stored
+            in the MAPS.""",
+    )
 
 
 @pytest.fixture
@@ -29,4 +37,5 @@ def cmdopt(request):
     config_param = {}
     config_param["input"] = request.config.getoption("--input_data_directory")
     config_param["simulate gpu"] = request.config.getoption("--simulate-gpu")
+    config_param["adapt base dir"] = request.config.getoption("--adapt-base-dir")
     return config_param

--- a/tests/test_train_ae.py
+++ b/tests/test_train_ae.py
@@ -88,7 +88,7 @@ def test_train_ae(cmdopt, tmp_path, test_name):
     else:
         raise NotImplementedError(f"Test {test_name} is not implemented.")
 
-    if cmdopt["simulate gpu"]:
+    if cmdopt["no-gpu"]:
         test_input.append("--no-gpu")
 
     if tmp_out_dir.is_dir():
@@ -104,16 +104,16 @@ def test_train_ae(cmdopt, tmp_path, test_name):
 
     if test_name == "patch_multi_ae":
         json_data_out["multi_network"] = True
-    if cmdopt["simulate gpu"]:
-        json_data_out["gpu"] = True
-    if cmdopt["adapt base dir"]:
+    if cmdopt["no-gpu"]:
+        json_data_ref["gpu"] = False
+    if cmdopt["adapt-base-dir"]:
         base_dir = base_dir.resolve()
         ref_base_dir = Path(json_data_ref["caps_directory"]).parents[2]
-        json_data_out["caps_directory"] = str(
-            ref_base_dir / Path(json_data_out["caps_directory"]).relative_to(base_dir)
+        json_data_ref["caps_directory"] = str(
+            base_dir / Path(json_data_ref["caps_directory"]).relative_to(ref_base_dir)
         )
-        json_data_out["tsv_path"] = str(
-            ref_base_dir / Path(json_data_out["tsv_path"]).relative_to(base_dir)
+        json_data_ref["tsv_path"] = str(
+            base_dir / Path(json_data_ref["tsv_path"]).relative_to(ref_base_dir)
         )
     assert json_data_out == json_data_ref  # ["mode"] == mode
 

--- a/tests/test_train_ae.py
+++ b/tests/test_train_ae.py
@@ -24,7 +24,7 @@ def test_name(request):
 
 
 def test_train_ae(cmdopt, tmp_path, test_name):
-    base_dir = Path(cmdopt["input"]).resolve()
+    base_dir = Path(cmdopt["input"])
     input_dir = base_dir / "train" / "in"
     ref_dir = base_dir / "train" / "ref"
     tmp_out_dir = base_dir / "train" / "out"
@@ -107,6 +107,7 @@ def test_train_ae(cmdopt, tmp_path, test_name):
     if cmdopt["simulate gpu"]:
         json_data_out["gpu"] = True
     if cmdopt["adapt base dir"]:
+        base_dir = base_dir.resolve()
         ref_base_dir = Path(json_data_ref["caps_directory"]).parents[2]
         json_data_out["caps_directory"] = str(
             ref_base_dir / Path(json_data_out["caps_directory"]).relative_to(base_dir)

--- a/tests/test_train_ae.py
+++ b/tests/test_train_ae.py
@@ -24,7 +24,7 @@ def test_name(request):
 
 
 def test_train_ae(cmdopt, tmp_path, test_name):
-    base_dir = Path(cmdopt["input"])
+    base_dir = Path(cmdopt["input"]).resolve()
     input_dir = base_dir / "train" / "in"
     ref_dir = base_dir / "train" / "ref"
     tmp_out_dir = base_dir / "train" / "out"
@@ -88,6 +88,9 @@ def test_train_ae(cmdopt, tmp_path, test_name):
     else:
         raise NotImplementedError(f"Test {test_name} is not implemented.")
 
+    if cmdopt["simulate gpu"]:
+        test_input.append("--no-gpu")
+
     if tmp_out_dir.is_dir():
         shutil.rmtree(tmp_out_dir)
 
@@ -101,6 +104,16 @@ def test_train_ae(cmdopt, tmp_path, test_name):
 
     if test_name == "patch_multi_ae":
         json_data_out["multi_network"] = True
+    if cmdopt["simulate gpu"]:
+        json_data_out["gpu"] = True
+    if cmdopt["adapt base dir"]:
+        ref_base_dir = Path(json_data_ref["caps_directory"]).parents[2]
+        json_data_out["caps_directory"] = str(
+            ref_base_dir / Path(json_data_out["caps_directory"]).relative_to(base_dir)
+        )
+        json_data_out["tsv_path"] = str(
+            ref_base_dir / Path(json_data_out["tsv_path"]).relative_to(base_dir)
+        )
     assert json_data_out == json_data_ref  # ["mode"] == mode
 
     assert compare_folders(


### PR DESCRIPTION
I propose to add two flags to the pytest command lines to enable developers to run functional tests locally without changing the CI data:
- `--no-gpu` enables to run successfully a test on a cpu-only device without changing `gpu` to `false` in the `maps.json` file.
- `--adapt-base-dir` enables to run successfully a test without changing the paths in the `maps.json` file.

A developer could then run a test with something like:
```bash
poetry run pytest --verbose \ 
 --basetemp=/tmp/train \
 --input_data_directory=/Users/thibault.devarax/Desktop/code/clinicadl_data_ci/data_ci/ \
 --no-gpu \
 --adapt-base-dir \
 tests/test_train_ae.py
```

These two options work by virtually modifying the CI data (e.g. `gpu` will be set to `false`). So, I do agree that this is risky. But, I find this solution better than concretely modifying the CI data.
Let me stress that these flags should not be used for the final CI tests run on GitHub and should be only helpful when a developer wants to run the tests locally.

Anyways, this is just a suggestion, so feel free to comment or offer other solutions. Once we agree on a solution, I will extend it to all the tests.