### PR TITLE
[INFRA] Update the Makefile `check.lock` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ help: Makefile
 
 .PHONY: check.lock
 check.lock:
-	@$(POETRY) lock --check
+	@$(POETRY) check --lock
 
 ## build			: Build the package.
 .PHONY: build


### PR DESCRIPTION
Will fix the deprecation warning: 

poetry lock --check is deprecated, use `poetry check --lock` instead.