### PR TITLE
Trigger tests when undrafted

### DIFF
--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -5,6 +5,7 @@ on:
     branches: ["dev", "refactoring"]
   pull_request:
     branches: ["dev", "refactoring"]
+    types: [opened, edited, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -5,7 +5,7 @@ on:
     branches: ["dev", "refactoring"]
   pull_request:
     branches: ["dev", "refactoring"]
-    types: [opened, edited, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/test_generate.yml
+++ b/.github/workflows/test_generate.yml
@@ -5,6 +5,7 @@ on:
     branches: ["dev", "refactoring"]
   pull_request:
     branches: ["dev", "refactoring"]
+    types: [opened, edited, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/test_generate.yml
+++ b/.github/workflows/test_generate.yml
@@ -5,7 +5,7 @@ on:
     branches: ["dev", "refactoring"]
   pull_request:
     branches: ["dev", "refactoring"]
-    types: [opened, edited, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/test_interpret.yml
+++ b/.github/workflows/test_interpret.yml
@@ -5,6 +5,7 @@ on:
     branches: ["dev", "refactoring"]
   pull_request:
     branches: ["dev", "refactoring"]
+    types: [opened, edited, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/test_interpret.yml
+++ b/.github/workflows/test_interpret.yml
@@ -5,7 +5,7 @@ on:
     branches: ["dev", "refactoring"]
   pull_request:
     branches: ["dev", "refactoring"]
-    types: [opened, edited, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/test_predict.yml
+++ b/.github/workflows/test_predict.yml
@@ -5,6 +5,7 @@ on:
     branches: ["dev", "refactoring"]
   pull_request:
     branches: ["dev", "refactoring"]
+    types: [opened, edited, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/test_predict.yml
+++ b/.github/workflows/test_predict.yml
@@ -5,7 +5,7 @@ on:
     branches: ["dev", "refactoring"]
   pull_request:
     branches: ["dev", "refactoring"]
-    types: [opened, edited, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/test_prepare_data.yml
+++ b/.github/workflows/test_prepare_data.yml
@@ -5,6 +5,7 @@ on:
     branches: ["dev", "refactoring"]
   pull_request:
     branches: ["dev", "refactoring"]
+    types: [opened, edited, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/test_prepare_data.yml
+++ b/.github/workflows/test_prepare_data.yml
@@ -5,7 +5,7 @@ on:
     branches: ["dev", "refactoring"]
   pull_request:
     branches: ["dev", "refactoring"]
-    types: [opened, edited, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/test_quality_checks.yml
+++ b/.github/workflows/test_quality_checks.yml
@@ -5,6 +5,7 @@ on:
     branches: ["dev", "refactoring"]
   pull_request:
     branches: ["dev", "refactoring"]
+    types: [opened, edited, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/test_quality_checks.yml
+++ b/.github/workflows/test_quality_checks.yml
@@ -5,7 +5,7 @@ on:
     branches: ["dev", "refactoring"]
   pull_request:
     branches: ["dev", "refactoring"]
-    types: [opened, edited, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/test_random_search.yml
+++ b/.github/workflows/test_random_search.yml
@@ -5,6 +5,7 @@ on:
     branches: ["dev", "refactoring"]
   pull_request:
     branches: ["dev", "refactoring"]
+    types: [opened, edited, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/test_random_search.yml
+++ b/.github/workflows/test_random_search.yml
@@ -5,7 +5,7 @@ on:
     branches: ["dev", "refactoring"]
   pull_request:
     branches: ["dev", "refactoring"]
-    types: [opened, edited, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/test_resume.yml
+++ b/.github/workflows/test_resume.yml
@@ -5,6 +5,7 @@ on:
     branches: ["dev", "refactoring"]
   pull_request:
     branches: ["dev", "refactoring"]
+    types: [opened, edited, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/test_resume.yml
+++ b/.github/workflows/test_resume.yml
@@ -5,7 +5,7 @@ on:
     branches: ["dev", "refactoring"]
   pull_request:
     branches: ["dev", "refactoring"]
-    types: [opened, edited, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/test_train.yml
+++ b/.github/workflows/test_train.yml
@@ -5,6 +5,7 @@ on:
     branches: ["dev", "refactoring"]
   pull_request:
     branches: ["dev", "refactoring"]
+    types: [opened, edited, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/test_train.yml
+++ b/.github/workflows/test_train.yml
@@ -5,7 +5,7 @@ on:
     branches: ["dev", "refactoring"]
   pull_request:
     branches: ["dev", "refactoring"]
-    types: [opened, edited, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/test_transfer_learning.yml
+++ b/.github/workflows/test_transfer_learning.yml
@@ -5,6 +5,7 @@ on:
     branches: ["dev", "refactoring"]
   pull_request:
     branches: ["dev", "refactoring"]
+    types: [opened, edited, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/test_transfer_learning.yml
+++ b/.github/workflows/test_transfer_learning.yml
@@ -5,7 +5,7 @@ on:
     branches: ["dev", "refactoring"]
   pull_request:
     branches: ["dev", "refactoring"]
-    types: [opened, edited, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/test_tsvtools.yml
+++ b/.github/workflows/test_tsvtools.yml
@@ -5,6 +5,7 @@ on:
     branches: ["dev", "refactoring"]
   pull_request:
     branches: ["dev", "refactoring"]
+    types: [opened, edited, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/test_tsvtools.yml
+++ b/.github/workflows/test_tsvtools.yml
@@ -5,7 +5,7 @@ on:
     branches: ["dev", "refactoring"]
   pull_request:
     branches: ["dev", "refactoring"]
-    types: [opened, edited, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,10 +14,19 @@ def pytest_addoption(parser):
         action="store",
         help="Directory for (only-read) inputs for tests",
     )
+    parser.addoption(
+        "--simulate-gpu",
+        action="store_true",
+        help="""To simulate the presence of a gpu on a cpu-only device. Default is False.
+            To use carefully, only to run tests locally. Should not be used in final CI tests.
+            Concretely, the tests won't fail if gpu option if false in the output MAPS whereas
+            it should be true.""",
+    )
 
 
 @pytest.fixture
 def cmdopt(request):
     config_param = {}
     config_param["input"] = request.config.getoption("--input_data_directory")
+    config_param["simulate gpu"] = request.config.getoption("--simulate-gpu")
     return config_param


### PR DESCRIPTION
Currently, functional tests are not triggered when a PR is in draft mode. However, mark it as ready for review doesn't trigger the tests and it is necessary to push a fake commit to launch them.

I propose to specify the events that will trigger tests in a PR, and especially add the `ready_for_review` event. Formerly, the events were the [default ones](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows), i.e. `opened`, `synchronize` and `reopened`.

To summarize, if this PR is accepted:
- unittests and linter tests would always be run (even in draft mode),
- functional tests would not run in draft mode, but mark a PR as ready for review will trigger them.