### PR TITLE
remove non in implemented reductions

### DIFF
--- a/clinicadl/losses/config.py
+++ b/clinicadl/losses/config.py
@@ -47,7 +47,6 @@ class ImplementedLoss(str, Enum):
 class Reduction(str, Enum):
     """Supported reduction method in ClinicaDL."""
 
-    NONE = "none"
     MEAN = "mean"
     SUM = "sum"
 

--- a/clinicadl/losses/utils.py
+++ b/clinicadl/losses/utils.py
@@ -1,0 +1,10 @@
+from typing import Callable, Union
+
+from torch import Tensor
+from torch.nn.modules.loss import _Loss
+
+Loss = Union[
+    Callable[[Tensor], Tensor],
+    Callable[[Tensor, Tensor], Tensor],
+    _Loss,
+]

--- a/tests/unittests/losses/test_config.py
+++ b/tests/unittests/losses/test_config.py
@@ -6,12 +6,12 @@ from clinicadl.losses import LossConfig
 
 def test_LossConfig():
     config = LossConfig(
-        loss="SmoothL1Loss", margin=10.0, delta=2.0, reduction="none", weight=None
+        loss="SmoothL1Loss", margin=10.0, delta=2.0, reduction="sum", weight=None
     )
     assert config.loss == "SmoothL1Loss"
     assert config.margin == 10.0
     assert config.delta == 2.0
-    assert config.reduction == "none"
+    assert config.reduction == "sum"
     assert config.p == "DefaultFromLibrary"
 
     with pytest.raises(ValueError):


### PR DESCRIPTION
It is not possible to call `.backward()` on non-scalar.