### PR TITLE
Review of loss module

### DIFF
--- a/clinicadl/losses/__init__.py
+++ b/clinicadl/losses/__init__.py
@@ -1,2 +1,3 @@
-from .config import ClassificationLoss, ImplementedLoss, LossConfig
+from .config import create_loss_config
+from .enum import ClassificationLoss, ImplementedLoss
 from .factory import get_loss_function

--- a/clinicadl/losses/config.py
+++ b/clinicadl/losses/config.py
@@ -16,16 +16,16 @@ from .enum import ImplementedLoss, Order, Reduction
 
 __all__ = [
     "LossConfig",
-    "NLLConfig",
-    "CrossEntropyConfig",
-    "BCEConfig",
-    "BCEWithLogitsConfig",
-    "MultiMarginConfig",
-    "KLDivConfig",
-    "HuberConfig",
-    "SmoothL1Config",
-    "L1Config",
-    "MSEConfig",
+    "NLLLossConfig",
+    "CrossEntropyLossConfig",
+    "BCELossConfig",
+    "BCEWithLogitsLossConfig",
+    "MultiMarginLossConfig",
+    "KLDivLossConfig",
+    "HuberLossConfig",
+    "SmoothL1LossConfig",
+    "L1LossConfig",
+    "MSELossConfig",
     "create_loss_config",
 ]
 
@@ -45,20 +45,20 @@ class LossConfig(BaseModel, ABC):
     @computed_field
     @property
     @abstractmethod
-    def loss(self) -> str:
-        """The name of the loss."""
+    def loss(self) -> ImplementedLoss:
+        """ImplementedLoss.e name of the loss."""
 
 
-class NLLConfig(LossConfig):
+class NLLLossConfig(LossConfig):
     """Config class for Negative Log Likelihood loss."""
 
     ignore_index: Union[int, DefaultFromLibrary] = DefaultFromLibrary.YES
 
     @computed_field
     @property
-    def loss(self) -> str:
+    def loss(self) -> ImplementedLoss:
         """The name of the loss."""
-        return "NLLLoss"
+        return ImplementedLoss.NLL
 
     @field_validator("ignore_index")
     @classmethod
@@ -70,7 +70,7 @@ class NLLConfig(LossConfig):
         return v
 
 
-class CrossEntropyConfig(NLLConfig):
+class CrossEntropyLossConfig(NLLLossConfig):
     """Config class for Cross Entropy loss."""
 
     label_smoothing: Union[
@@ -79,9 +79,9 @@ class CrossEntropyConfig(NLLConfig):
 
     @computed_field
     @property
-    def loss(self) -> str:
+    def loss(self) -> ImplementedLoss:
         """The name of the loss."""
-        return "CrossEntropyLoss"
+        return ImplementedLoss.CROSS_ENTROPY
 
     @field_validator("label_smoothing")
     @classmethod
@@ -93,16 +93,16 @@ class CrossEntropyConfig(NLLConfig):
         return v
 
 
-class BCEConfig(LossConfig):
+class BCELossConfig(LossConfig):
     """Config class for Binary Cross Entropy loss."""
 
     weight: Optional[List[NonNegativeFloat]] = None
 
     @computed_field
     @property
-    def loss(self) -> str:
+    def loss(self) -> ImplementedLoss:
         """The name of the loss."""
-        return "BCELoss"
+        return ImplementedLoss.BCE
 
     @field_validator("weight")
     @classmethod
@@ -114,16 +114,16 @@ class BCEConfig(LossConfig):
         return v
 
 
-class BCEWithLogitsConfig(BCEConfig):
+class BCEWithLogitsLossConfig(BCELossConfig):
     """Config class for Binary Cross Entropy With Logits loss."""
 
     pos_weight: Union[Optional[List[Any]], DefaultFromLibrary] = DefaultFromLibrary.YES
 
     @computed_field
     @property
-    def loss(self) -> str:
+    def loss(self) -> ImplementedLoss:
         """The name of the loss."""
-        return "BCEWithLogitsLoss"
+        return ImplementedLoss.BCE_LOGITS
 
     @field_validator("pos_weight")
     @classmethod
@@ -144,7 +144,7 @@ class BCEWithLogitsConfig(BCEConfig):
             return (isinstance(item, float) or isinstance(item, int)) and item >= 0
 
 
-class MultiMarginConfig(LossConfig):
+class MultiMarginLossConfig(LossConfig):
     """Config class for Multi Margin loss."""
 
     p: Union[Order, DefaultFromLibrary] = DefaultFromLibrary.YES
@@ -152,65 +152,65 @@ class MultiMarginConfig(LossConfig):
 
     @computed_field
     @property
-    def loss(self) -> str:
+    def loss(self) -> ImplementedLoss:
         """The name of the loss."""
-        return "MultiMarginLoss"
+        return ImplementedLoss.MULTI_MARGIN
 
 
-class KLDivConfig(LossConfig):
+class KLDivLossConfig(LossConfig):
     """Config class for Kullback-Leibler Divergence loss."""
 
     log_target: Union[bool, DefaultFromLibrary] = DefaultFromLibrary.YES
 
     @computed_field
     @property
-    def loss(self) -> str:
+    def loss(self) -> ImplementedLoss:
         """The name of the loss."""
-        return "KLDivLoss"
+        return ImplementedLoss.KLDIV
 
 
-class HuberConfig(LossConfig):
+class HuberLossConfig(LossConfig):
     """Config class for Huber loss."""
 
     delta: Union[PositiveFloat, DefaultFromLibrary] = DefaultFromLibrary.YES
 
     @computed_field
     @property
-    def loss(self) -> str:
+    def loss(self) -> ImplementedLoss:
         """The name of the loss."""
-        return "HuberLoss"
+        return ImplementedLoss.HUBER
 
 
-class SmoothL1Config(LossConfig):
+class SmoothL1LossConfig(LossConfig):
     """Config class for Smooth L1 loss."""
 
     beta: Union[NonNegativeFloat, DefaultFromLibrary] = DefaultFromLibrary.YES
 
     @computed_field
     @property
-    def loss(self) -> str:
+    def loss(self) -> ImplementedLoss:
         """The name of the loss."""
-        return "SmoothL1Loss"
+        return ImplementedLoss.SMOOTH_L1
 
 
-class L1Config(LossConfig):
+class L1LossConfig(LossConfig):
     """Config class for L1 loss."""
 
     @computed_field
     @property
-    def loss(self) -> str:
+    def loss(self) -> ImplementedLoss:
         """The name of the loss."""
-        return "L1Loss"
+        return ImplementedLoss.L1
 
 
-class MSEConfig(LossConfig):
+class MSELossConfig(LossConfig):
     """Config class for Mean Squared Error loss."""
 
     @computed_field
     @property
-    def loss(self) -> str:
+    def loss(self) -> ImplementedLoss:
         """The name of the loss."""
-        return "MSELoss"
+        return ImplementedLoss.MSE
 
 
 def create_loss_config(
@@ -235,7 +235,7 @@ def create_loss_config(
         If `loss` is not supported.
     """
     loss = ImplementedLoss(loss)
-    config_name = "".join([loss.replace(" ", ""), "Config"])
+    config_name = "".join([loss, "Config"])
     config = globals()[config_name]
 
     return config

--- a/clinicadl/losses/config.py
+++ b/clinicadl/losses/config.py
@@ -1,96 +1,64 @@
-from enum import Enum
-from typing import List, Optional, Union
+from abc import ABC, abstractmethod
+from typing import Any, List, Optional, Type, Union
 
 from pydantic import (
     BaseModel,
     ConfigDict,
     NonNegativeFloat,
     PositiveFloat,
+    computed_field,
     field_validator,
-    model_validator,
 )
 
-from clinicadl.utils.enum import BaseEnum
 from clinicadl.utils.factories import DefaultFromLibrary
 
+from .enum import ImplementedLoss, Order, Reduction
 
-class ClassificationLoss(str, BaseEnum):
-    """Losses that can be used only for classification."""
-
-    CROSS_ENTROPY = "CrossEntropyLoss"  # for multi-class classification, inputs are unormalized logits and targets are int (same dimension without the class channel)
-    MULTI_MARGIN = "MultiMarginLoss"  # no particular restriction on the input, targets are int (same dimension without th class channel)
-    BCE = "BCELoss"  # for binary classification, targets and inputs should be probabilities and have same shape
-    BCE_LOGITS = "BCEWithLogitsLoss"  # for binary classification, targets should be probabilities and inputs logits, and have the same shape. More stable numerically
-
-
-class ImplementedLoss(str, Enum):
-    """Implemented losses in ClinicaDL."""
-
-    CROSS_ENTROPY = "CrossEntropyLoss"
-    MULTI_MARGIN = "MultiMarginLoss"
-    BCE = "BCELoss"
-    BCE_LOGITS = "BCEWithLogitsLoss"
-    L1 = "L1Loss"
-    MSE = "MSELoss"
-    HUBER = "HuberLoss"
-    SMOOTH_L1 = "SmoothL1Loss"
-    KLDIV = "KLDivLoss"  # if log_target=False, target must be positive
-
-    @classmethod
-    def _missing_(cls, value):
-        raise ValueError(
-            f"{value} is not implemented. Implemented losses are: "
-            + ", ".join([repr(m.value) for m in cls])
-        )
+__all__ = [
+    "LossConfig",
+    "NLLConfig",
+    "CrossEntropyConfig",
+    "BCEConfig",
+    "BCEWithLogitsConfig",
+    "MultiMarginConfig",
+    "KLDivConfig",
+    "HuberConfig",
+    "SmoothL1Config",
+    "L1Config",
+    "MSEConfig",
+    "create_loss_config",
+]
 
 
-class Reduction(str, Enum):
-    """Supported reduction method in ClinicaDL."""
+class LossConfig(BaseModel, ABC):
+    """Base config class for the loss function."""
 
-    MEAN = "mean"
-    SUM = "sum"
-
-
-class Order(int, Enum):
-    """Supported order of L-norm for MultiMarginLoss."""
-
-    ONE = 1
-    TWO = 2
-
-
-class LossConfig(BaseModel):
-    """Config class to configure the loss function."""
-
-    loss: ImplementedLoss = ImplementedLoss.MSE
     reduction: Union[Reduction, DefaultFromLibrary] = DefaultFromLibrary.YES
-    delta: Union[PositiveFloat, DefaultFromLibrary] = DefaultFromLibrary.YES
-    beta: Union[PositiveFloat, DefaultFromLibrary] = DefaultFromLibrary.YES
-    p: Union[Order, DefaultFromLibrary] = DefaultFromLibrary.YES
-    margin: Union[float, DefaultFromLibrary] = DefaultFromLibrary.YES
     weight: Union[
         Optional[List[NonNegativeFloat]], DefaultFromLibrary
-    ] = DefaultFromLibrary.YES  # a weight for each class
-    ignore_index: Union[int, DefaultFromLibrary] = DefaultFromLibrary.YES
-    label_smoothing: Union[
-        NonNegativeFloat, DefaultFromLibrary
     ] = DefaultFromLibrary.YES
-    log_target: Union[bool, DefaultFromLibrary] = DefaultFromLibrary.YES
-    pos_weight: Union[
-        Optional[List[NonNegativeFloat]], DefaultFromLibrary
-    ] = DefaultFromLibrary.YES  # a positive weight for each class
     # pydantic config
     model_config = ConfigDict(
         validate_assignment=True, use_enum_values=True, validate_default=True
     )
 
-    @field_validator("label_smoothing")
-    @classmethod
-    def validator_label_smoothing(cls, v):
-        if isinstance(v, float):
-            assert (
-                0 <= v <= 1
-            ), f"label_smoothing must be between 0 and 1 but it has been set to {v}."
-        return v
+    @computed_field
+    @property
+    @abstractmethod
+    def loss(self) -> str:
+        """The name of the loss."""
+
+
+class NLLConfig(LossConfig):
+    """Config class for Negative Log Likelihood loss."""
+
+    ignore_index: Union[int, DefaultFromLibrary] = DefaultFromLibrary.YES
+
+    @computed_field
+    @property
+    def loss(self) -> str:
+        """The name of the loss."""
+        return "NLLLoss"
 
     @field_validator("ignore_index")
     @classmethod
@@ -101,17 +69,173 @@ class LossConfig(BaseModel):
             ), "ignore_index must be a positive int (or -100 when disabled)."
         return v
 
-    @model_validator(mode="after")
-    def model_validator(self):
-        if (
-            self.loss == ImplementedLoss.BCE_LOGITS
-            and self.weight is not None
-            and self.weight != DefaultFromLibrary.YES
-        ):
-            raise ValueError("Cannot use weight with BCEWithLogitsLoss.")
-        elif (
-            self.loss == ImplementedLoss.BCE
-            and self.weight is not None
-            and self.weight != DefaultFromLibrary.YES
-        ):
-            raise ValueError("Cannot use weight with BCELoss.")
+
+class CrossEntropyConfig(NLLConfig):
+    """Config class for Cross Entropy loss."""
+
+    label_smoothing: Union[
+        NonNegativeFloat, DefaultFromLibrary
+    ] = DefaultFromLibrary.YES
+
+    @computed_field
+    @property
+    def loss(self) -> str:
+        """The name of the loss."""
+        return "CrossEntropyLoss"
+
+    @field_validator("label_smoothing")
+    @classmethod
+    def validator_label_smoothing(cls, v):
+        if isinstance(v, float):
+            assert (
+                0 <= v <= 1
+            ), f"label_smoothing must be between 0 and 1 but it has been set to {v}."
+        return v
+
+
+class BCEConfig(LossConfig):
+    """Config class for Binary Cross Entropy loss."""
+
+    weight: Optional[List[NonNegativeFloat]] = None
+
+    @computed_field
+    @property
+    def loss(self) -> str:
+        """The name of the loss."""
+        return "BCELoss"
+
+    @field_validator("weight")
+    @classmethod
+    def validator_weight(cls, v):
+        if v is not None:
+            raise ValueError(
+                "Cannot use weight with BCEWithLogitsLoss. If you want more flexibility, please use API mode."
+            )
+        return v
+
+
+class BCEWithLogitsConfig(BCEConfig):
+    """Config class for Binary Cross Entropy With Logits loss."""
+
+    pos_weight: Union[Optional[List[Any]], DefaultFromLibrary] = DefaultFromLibrary.YES
+
+    @computed_field
+    @property
+    def loss(self) -> str:
+        """The name of the loss."""
+        return "BCEWithLogitsLoss"
+
+    @field_validator("pos_weight")
+    @classmethod
+    def validator_pos_weight(cls, v):
+        if isinstance(v, list):
+            check = cls._recursive_float_check(v)
+            if not check:
+                raise ValueError(
+                    f"elements in pos_weight must be non-negative float, got: {v}"
+                )
+        return v
+
+    @classmethod
+    def _recursive_float_check(cls, item):
+        if isinstance(item, list):
+            return all(cls._recursive_float_check(i) for i in item)
+        else:
+            return (isinstance(item, float) or isinstance(item, int)) and item >= 0
+
+
+class MultiMarginConfig(LossConfig):
+    """Config class for Multi Margin loss."""
+
+    p: Union[Order, DefaultFromLibrary] = DefaultFromLibrary.YES
+    margin: Union[float, DefaultFromLibrary] = DefaultFromLibrary.YES
+
+    @computed_field
+    @property
+    def loss(self) -> str:
+        """The name of the loss."""
+        return "MultiMarginLoss"
+
+
+class KLDivConfig(LossConfig):
+    """Config class for Kullback-Leibler Divergence loss."""
+
+    log_target: Union[bool, DefaultFromLibrary] = DefaultFromLibrary.YES
+
+    @computed_field
+    @property
+    def loss(self) -> str:
+        """The name of the loss."""
+        return "KLDivLoss"
+
+
+class HuberConfig(LossConfig):
+    """Config class for Huber loss."""
+
+    delta: Union[PositiveFloat, DefaultFromLibrary] = DefaultFromLibrary.YES
+
+    @computed_field
+    @property
+    def loss(self) -> str:
+        """The name of the loss."""
+        return "HuberLoss"
+
+
+class SmoothL1Config(LossConfig):
+    """Config class for Smooth L1 loss."""
+
+    beta: Union[NonNegativeFloat, DefaultFromLibrary] = DefaultFromLibrary.YES
+
+    @computed_field
+    @property
+    def loss(self) -> str:
+        """The name of the loss."""
+        return "SmoothL1Loss"
+
+
+class L1Config(LossConfig):
+    """Config class for L1 loss."""
+
+    @computed_field
+    @property
+    def loss(self) -> str:
+        """The name of the loss."""
+        return "L1Loss"
+
+
+class MSEConfig(LossConfig):
+    """Config class for Mean Squared Error loss."""
+
+    @computed_field
+    @property
+    def loss(self) -> str:
+        """The name of the loss."""
+        return "MSELoss"
+
+
+def create_loss_config(
+    loss: Union[str, ImplementedLoss],
+) -> Type[LossConfig]:
+    """
+    A factory function to create a config class suited for the loss.
+
+    Parameters
+    ----------
+    loss : Union[str, ImplementedLoss]
+        The name of the loss.
+
+    Returns
+    -------
+    Type[LossConfig]
+        The config class.
+
+    Raises
+    ------
+    ValueError
+        If `loss` is not supported.
+    """
+    loss = ImplementedLoss(loss)
+    config_name = "".join([loss.replace(" ", ""), "Config"])
+    config = globals()[config_name]
+
+    return config

--- a/clinicadl/losses/config.py
+++ b/clinicadl/losses/config.py
@@ -1,97 +1,64 @@
-from enum import Enum
-from typing import List, Optional, Union
+from abc import ABC, abstractmethod
+from typing import Any, List, Optional, Type, Union
 
 from pydantic import (
     BaseModel,
     ConfigDict,
     NonNegativeFloat,
     PositiveFloat,
+    computed_field,
     field_validator,
-    model_validator,
 )
 
-from clinicadl.utils.enum import BaseEnum
 from clinicadl.utils.factories import DefaultFromLibrary
 
+from .enum import ImplementedLoss, Order, Reduction
 
-class ClassificationLoss(str, BaseEnum):
-    """Losses that can be used only for classification."""
-
-    CROSS_ENTROPY = "CrossEntropyLoss"  # for multi-class classification, inputs are unormalized logits and targets are int (same dimension without the class channel)
-    MULTI_MARGIN = "MultiMarginLoss"  # no particular restriction on the input, targets are int (same dimension without th class channel)
-    BCE = "BCELoss"  # for binary classification, targets and inputs should be probabilities and have same shape
-    BCE_LOGITS = "BCEWithLogitsLoss"  # for binary classification, targets should be probabilities and inputs logits, and have the same shape. More stable numerically
-
-
-class ImplementedLoss(str, Enum):
-    """Implemented losses in ClinicaDL."""
-
-    CROSS_ENTROPY = "CrossEntropyLoss"
-    MULTI_MARGIN = "MultiMarginLoss"
-    BCE = "BCELoss"
-    BCE_LOGITS = "BCEWithLogitsLoss"
-    L1 = "L1Loss"
-    MSE = "MSELoss"
-    HUBER = "HuberLoss"
-    SMOOTH_L1 = "SmoothL1Loss"
-    KLDIV = "KLDivLoss"  # if log_target=False, target must be positive
-
-    @classmethod
-    def _missing_(cls, value):
-        raise ValueError(
-            f"{value} is not implemented. Implemented losses are: "
-            + ", ".join([repr(m.value) for m in cls])
-        )
+__all__ = [
+    "LossConfig",
+    "NLLConfig",
+    "CrossEntropyConfig",
+    "BCEConfig",
+    "BCEWithLogitsConfig",
+    "MultiMarginConfig",
+    "KLDivConfig",
+    "HuberConfig",
+    "SmoothL1Config",
+    "L1Config",
+    "MSEConfig",
+    "create_loss_config",
+]
 
 
-class Reduction(str, Enum):
-    """Supported reduction method in ClinicaDL."""
+class LossConfig(BaseModel, ABC):
+    """Base config class for the loss function."""
 
-    NONE = "none"
-    MEAN = "mean"
-    SUM = "sum"
-
-
-class Order(int, Enum):
-    """Supported order of L-norm for MultiMarginLoss."""
-
-    ONE = 1
-    TWO = 2
-
-
-class LossConfig(BaseModel):
-    """Config class to configure the loss function."""
-
-    loss: ImplementedLoss = ImplementedLoss.MSE
     reduction: Union[Reduction, DefaultFromLibrary] = DefaultFromLibrary.YES
-    delta: Union[PositiveFloat, DefaultFromLibrary] = DefaultFromLibrary.YES
-    beta: Union[PositiveFloat, DefaultFromLibrary] = DefaultFromLibrary.YES
-    p: Union[Order, DefaultFromLibrary] = DefaultFromLibrary.YES
-    margin: Union[float, DefaultFromLibrary] = DefaultFromLibrary.YES
     weight: Union[
         Optional[List[NonNegativeFloat]], DefaultFromLibrary
-    ] = DefaultFromLibrary.YES  # a weight for each class
-    ignore_index: Union[int, DefaultFromLibrary] = DefaultFromLibrary.YES
-    label_smoothing: Union[
-        NonNegativeFloat, DefaultFromLibrary
     ] = DefaultFromLibrary.YES
-    log_target: Union[bool, DefaultFromLibrary] = DefaultFromLibrary.YES
-    pos_weight: Union[
-        Optional[List[NonNegativeFloat]], DefaultFromLibrary
-    ] = DefaultFromLibrary.YES  # a positive weight for each class
     # pydantic config
     model_config = ConfigDict(
         validate_assignment=True, use_enum_values=True, validate_default=True
     )
 
-    @field_validator("label_smoothing")
-    @classmethod
-    def validator_label_smoothing(cls, v):
-        if isinstance(v, float):
-            assert (
-                0 <= v <= 1
-            ), f"label_smoothing must be between 0 and 1 but it has been set to {v}."
-        return v
+    @computed_field
+    @property
+    @abstractmethod
+    def loss(self) -> str:
+        """The name of the loss."""
+
+
+class NLLConfig(LossConfig):
+    """Config class for Negative Log Likelihood loss."""
+
+    ignore_index: Union[int, DefaultFromLibrary] = DefaultFromLibrary.YES
+
+    @computed_field
+    @property
+    def loss(self) -> str:
+        """The name of the loss."""
+        return "NLLLoss"
 
     @field_validator("ignore_index")
     @classmethod
@@ -102,17 +69,173 @@ class LossConfig(BaseModel):
             ), "ignore_index must be a positive int (or -100 when disabled)."
         return v
 
-    @model_validator(mode="after")
-    def model_validator(self):
-        if (
-            self.loss == ImplementedLoss.BCE_LOGITS
-            and self.weight is not None
-            and self.weight != DefaultFromLibrary.YES
-        ):
-            raise ValueError("Cannot use weight with BCEWithLogitsLoss.")
-        elif (
-            self.loss == ImplementedLoss.BCE
-            and self.weight is not None
-            and self.weight != DefaultFromLibrary.YES
-        ):
-            raise ValueError("Cannot use weight with BCELoss.")
+
+class CrossEntropyConfig(NLLConfig):
+    """Config class for Cross Entropy loss."""
+
+    label_smoothing: Union[
+        NonNegativeFloat, DefaultFromLibrary
+    ] = DefaultFromLibrary.YES
+
+    @computed_field
+    @property
+    def loss(self) -> str:
+        """The name of the loss."""
+        return "CrossEntropyLoss"
+
+    @field_validator("label_smoothing")
+    @classmethod
+    def validator_label_smoothing(cls, v):
+        if isinstance(v, float):
+            assert (
+                0 <= v <= 1
+            ), f"label_smoothing must be between 0 and 1 but it has been set to {v}."
+        return v
+
+
+class BCEConfig(LossConfig):
+    """Config class for Binary Cross Entropy loss."""
+
+    weight: Optional[List[NonNegativeFloat]] = None
+
+    @computed_field
+    @property
+    def loss(self) -> str:
+        """The name of the loss."""
+        return "BCELoss"
+
+    @field_validator("weight")
+    @classmethod
+    def validator_weight(cls, v):
+        if v is not None:
+            raise ValueError(
+                "Cannot use weight with BCEWithLogitsLoss. If you want more flexibility, please use API mode."
+            )
+        return v
+
+
+class BCEWithLogitsConfig(BCEConfig):
+    """Config class for Binary Cross Entropy With Logits loss."""
+
+    pos_weight: Union[Optional[List[Any]], DefaultFromLibrary] = DefaultFromLibrary.YES
+
+    @computed_field
+    @property
+    def loss(self) -> str:
+        """The name of the loss."""
+        return "BCEWithLogitsLoss"
+
+    @field_validator("pos_weight")
+    @classmethod
+    def validator_pos_weight(cls, v):
+        if isinstance(v, list):
+            check = cls._recursive_float_check(v)
+            if not check:
+                raise ValueError(
+                    f"elements in pos_weight must be non-negative float, got: {v}"
+                )
+        return v
+
+    @classmethod
+    def _recursive_float_check(cls, item):
+        if isinstance(item, list):
+            return all(cls._recursive_float_check(i) for i in item)
+        else:
+            return (isinstance(item, float) or isinstance(item, int)) and item >= 0
+
+
+class MultiMarginConfig(LossConfig):
+    """Config class for Multi Margin loss."""
+
+    p: Union[Order, DefaultFromLibrary] = DefaultFromLibrary.YES
+    margin: Union[float, DefaultFromLibrary] = DefaultFromLibrary.YES
+
+    @computed_field
+    @property
+    def loss(self) -> str:
+        """The name of the loss."""
+        return "MultiMarginLoss"
+
+
+class KLDivConfig(LossConfig):
+    """Config class for Kullback-Leibler Divergence loss."""
+
+    log_target: Union[bool, DefaultFromLibrary] = DefaultFromLibrary.YES
+
+    @computed_field
+    @property
+    def loss(self) -> str:
+        """The name of the loss."""
+        return "KLDivLoss"
+
+
+class HuberConfig(LossConfig):
+    """Config class for Huber loss."""
+
+    delta: Union[PositiveFloat, DefaultFromLibrary] = DefaultFromLibrary.YES
+
+    @computed_field
+    @property
+    def loss(self) -> str:
+        """The name of the loss."""
+        return "HuberLoss"
+
+
+class SmoothL1Config(LossConfig):
+    """Config class for Smooth L1 loss."""
+
+    beta: Union[NonNegativeFloat, DefaultFromLibrary] = DefaultFromLibrary.YES
+
+    @computed_field
+    @property
+    def loss(self) -> str:
+        """The name of the loss."""
+        return "SmoothL1Loss"
+
+
+class L1Config(LossConfig):
+    """Config class for L1 loss."""
+
+    @computed_field
+    @property
+    def loss(self) -> str:
+        """The name of the loss."""
+        return "L1Loss"
+
+
+class MSEConfig(LossConfig):
+    """Config class for Mean Squared Error loss."""
+
+    @computed_field
+    @property
+    def loss(self) -> str:
+        """The name of the loss."""
+        return "MSELoss"
+
+
+def create_loss_config(
+    loss: Union[str, ImplementedLoss],
+) -> Type[LossConfig]:
+    """
+    A factory function to create a config class suited for the loss.
+
+    Parameters
+    ----------
+    loss : Union[str, ImplementedLoss]
+        The name of the loss.
+
+    Returns
+    -------
+    Type[LossConfig]
+        The config class.
+
+    Raises
+    ------
+    ValueError
+        If `loss` is not supported.
+    """
+    loss = ImplementedLoss(loss)
+    config_name = "".join([loss.replace(" ", ""), "Config"])
+    config = globals()[config_name]
+
+    return config

--- a/clinicadl/losses/enum.py
+++ b/clinicadl/losses/enum.py
@@ -1,0 +1,50 @@
+from enum import Enum
+
+from clinicadl.utils.enum import BaseEnum
+
+
+class ClassificationLoss(str, BaseEnum):
+    """Losses that can be used only for classification."""
+
+    CROSS_ENTROPY = "Cross Entropy"  # for multi-class classification, inputs are unormalized logits and targets are int (same dimension without the class channel)
+    NLL = "NLL"  # for multi-class classification, inputs are log-probabilities and targets are int (same dimension without the class channel)
+    MULTI_MARGIN = "Multi Margin"  # no particular restriction on the input, targets are int (same dimension without th class channel)
+    BCE = "BCE"  # for binary classification, targets and inputs should be probabilities and have same shape
+    BCE_LOGITS = "BCE With Logits"  # for binary classification, targets should be probabilities and inputs logits, and have the same shape. More stable numerically
+
+
+class ImplementedLoss(str, Enum):
+    """Implemented losses in ClinicaDL."""
+
+    CROSS_ENTROPY = "Cross Entropy"
+    NLL = "NLL"
+    MULTI_MARGIN = "Multi Margin"
+    BCE = "BCE"
+    BCE_LOGITS = "BCE With Logits"
+
+    L1 = "L1"
+    MSE = "MSE"
+    HUBER = "Huber"
+    SMOOTH_L1 = "Smooth L1"
+    KLDIV = "KL Div"  # if log_target=False, target must be positive
+
+    @classmethod
+    def _missing_(cls, value):
+        raise ValueError(
+            f"{value} is not implemented. Implemented losses are: "
+            + ", ".join([repr(m.value) for m in cls])
+        )
+
+
+class Reduction(str, Enum):
+    """Supported reduction method in ClinicaDL."""
+
+    MEAN = "mean"
+    SUM = "sum"
+
+
+class Order(int, Enum):
+    """Supported order of L-norm for MultiMarginLoss."""
+
+    ONE = 1
+    TWO = 2

--- a/clinicadl/losses/enum.py
+++ b/clinicadl/losses/enum.py
@@ -6,27 +6,27 @@ from clinicadl.utils.enum import BaseEnum
 class ClassificationLoss(str, BaseEnum):
     """Losses that can be used only for classification."""
 
-    CROSS_ENTROPY = "Cross Entropy"  # for multi-class classification, inputs are unormalized logits and targets are int (same dimension without the class channel)
-    NLL = "NLL"  # for multi-class classification, inputs are log-probabilities and targets are int (same dimension without the class channel)
-    MULTI_MARGIN = "Multi Margin"  # no particular restriction on the input, targets are int (same dimension without th class channel)
-    BCE = "BCE"  # for binary classification, targets and inputs should be probabilities and have same shape
-    BCE_LOGITS = "BCE With Logits"  # for binary classification, targets should be probabilities and inputs logits, and have the same shape. More stable numerically
+    CROSS_ENTROPY = "CrossEntropyLoss"  # for multi-class classification, inputs are unormalized logits and targets are int (same dimension without the class channel)
+    NLL = "NLLLoss"  # for multi-class classification, inputs are log-probabilities and targets are int (same dimension without the class channel)
+    MULTI_MARGIN = "MultiMarginLoss"  # no particular restriction on the input, targets are int (same dimension without th class channel)
+    BCE = "BCELoss"  # for binary classification, targets and inputs should be probabilities and have same shape
+    BCE_LOGITS = "BCEWithLogitsLoss"  # for binary classification, targets should be probabilities and inputs logits, and have the same shape. More stable numerically
 
 
 class ImplementedLoss(str, Enum):
     """Implemented losses in ClinicaDL."""
 
-    CROSS_ENTROPY = "Cross Entropy"
-    NLL = "NLL"
-    MULTI_MARGIN = "Multi Margin"
-    BCE = "BCE"
-    BCE_LOGITS = "BCE With Logits"
+    CROSS_ENTROPY = "CrossEntropyLoss"
+    NLL = "NLLLoss"
+    MULTI_MARGIN = "MultiMarginLoss"
+    BCE = "BCELoss"
+    BCE_LOGITS = "BCEWithLogitsLoss"
 
-    L1 = "L1"
-    MSE = "MSE"
-    HUBER = "Huber"
-    SMOOTH_L1 = "Smooth L1"
-    KLDIV = "KL Div"  # if log_target=False, target must be positive
+    L1 = "L1Loss"
+    MSE = "MSELoss"
+    HUBER = "HuberLoss"
+    SMOOTH_L1 = "SmoothL1Loss"
+    KLDIV = "KLDivLoss"  # if log_target=False, target must be positive
 
     @classmethod
     def _missing_(cls, value):

--- a/clinicadl/losses/factory.py
+++ b/clinicadl/losses/factory.py
@@ -39,6 +39,6 @@ def get_loss_function(config: LossConfig) -> Tuple[torch.nn.Module, LossConfig]:
         config_dict_["pos_weight"] = torch.Tensor(config_dict_["pos_weight"])
     loss = loss_class(**config_dict_)
 
-    updated_config = LossConfig(loss=config.loss, **config_dict)
+    updated_config = config.model_copy(update=config_dict)
 
     return loss, updated_config

--- a/tests/unittests/losses/test_config.py
+++ b/tests/unittests/losses/test_config.py
@@ -47,7 +47,7 @@ from clinicadl.losses.config import (
     ],
 )
 def test_validation_fail(config, args):
-    with pytest.raises((ValidationError, ValueError)):
+    with pytest.raises(ValidationError):
         config(**args)
 
 

--- a/tests/unittests/losses/test_config.py
+++ b/tests/unittests/losses/test_config.py
@@ -1,35 +1,101 @@
 import pytest
+import torch
 from pydantic import ValidationError
 
-from clinicadl.losses import LossConfig
+from clinicadl.losses import ImplementedLoss
+from clinicadl.losses.config import (
+    BCEConfig,
+    BCEWithLogitsConfig,
+    CrossEntropyConfig,
+    HuberConfig,
+    KLDivConfig,
+    L1Config,
+    MSEConfig,
+    MultiMarginConfig,
+    NLLConfig,
+    SmoothL1Config,
+    create_loss_config,
+)
 
 
-def test_LossConfig():
-    config = LossConfig(
-        loss="SmoothL1Loss", margin=10.0, delta=2.0, reduction="sum", weight=None
+@pytest.mark.parametrize(
+    "config,args",
+    [
+        (L1Config, {"reduction": "none"}),
+        (MSEConfig, {"reduction": "none"}),
+        (CrossEntropyConfig, {"reduction": "none"}),
+        (CrossEntropyConfig, {"weight": [1, -1, 2]}),
+        (CrossEntropyConfig, {"ignore_index": -1}),
+        (CrossEntropyConfig, {"label_smoothing": 1.1}),
+        (NLLConfig, {"reduction": "none"}),
+        (NLLConfig, {"weight": [1, -1, 2]}),
+        (NLLConfig, {"ignore_index": -1}),
+        (KLDivConfig, {"reduction": "none"}),
+        (BCEConfig, {"reduction": "none"}),
+        (BCEConfig, {"weight": [0, 1]}),
+        (BCEWithLogitsConfig, {"reduction": "none"}),
+        (BCEWithLogitsConfig, {"weight": [0, 1]}),
+        (BCEWithLogitsConfig, {"pos_weight": [[1, -1, 2]]}),
+        (BCEWithLogitsConfig, {"pos_weight": [["a", "b"]]}),
+        (HuberConfig, {"reduction": "none"}),
+        (HuberConfig, {"delta": 0.0}),
+        (SmoothL1Config, {"reduction": "none"}),
+        (SmoothL1Config, {"beta": -1.0}),
+        (MultiMarginConfig, {"reduction": "none"}),
+        (MultiMarginConfig, {"p": 3}),
+        (MultiMarginConfig, {"weight": [1, -1, 2]}),
+    ],
+)
+def test_validation_fail(config, args):
+    with pytest.raises((ValidationError, ValueError)):
+        config(**args)
+
+
+@pytest.mark.parametrize(
+    "config,args",
+    [
+        (L1Config, {"reduction": "mean"}),
+        (MSEConfig, {"reduction": "mean"}),
+        (
+            CrossEntropyConfig,
+            {
+                "reduction": "mean",
+                "weight": [1, 0, 2],
+                "ignore_index": 1,
+                "label_smoothing": 0.5,
+            },
+        ),
+        (NLLConfig, {"reduction": "mean", "weight": [1, 0, 2], "ignore_index": 1}),
+        (KLDivConfig, {"reduction": "mean", "log_target": True}),
+        (BCEConfig, {"reduction": "sum", "weight": None}),
+        (
+            BCEWithLogitsConfig,
+            {"reduction": "sum", "weight": None, "pos_weight": [[1, 0, 2]]},
+        ),
+        (HuberConfig, {"reduction": "sum", "delta": 0.1}),
+        (SmoothL1Config, {"reduction": "sum", "beta": 0.0}),
+        (
+            MultiMarginConfig,
+            {"reduction": "sum", "p": 1, "margin": -0.1, "weight": [1, 0, 2]},
+        ),
+    ],
+)
+def test_validation_pass(config, args):
+    c = config(**args)
+    for arg, value in args.items():
+        assert getattr(c, arg) == value
+
+
+def test_create_loss_config():
+    for loss in ImplementedLoss:
+        create_loss_config(loss)
+
+    config_class = create_loss_config("Multi Margin")
+    config = config_class(
+        margin=0.1,
+        reduction="sum",
     )
-    assert config.loss == "SmoothL1Loss"
-    assert config.margin == 10.0
-    assert config.delta == 2.0
-    assert config.reduction == "sum"
+    assert isinstance(config, MultiMarginConfig)
     assert config.p == "DefaultFromLibrary"
-
-    with pytest.raises(ValueError):
-        LossConfig(loss="abc")
-    with pytest.raises(ValueError):
-        LossConfig(weight=[0.1, -0.1, 0.8])
-    with pytest.raises(ValueError):
-        LossConfig(p=3)
-    with pytest.raises(ValueError):
-        LossConfig(reduction="abc")
-    with pytest.raises(ValidationError):
-        LossConfig(label_smoothing=1.1)
-    with pytest.raises(ValidationError):
-        LossConfig(ignore_index=-1)
-    with pytest.raises(ValidationError):
-        LossConfig(loss="BCEWithLogitsLoss", weight=[1, 2, 3])
-    with pytest.raises(ValidationError):
-        LossConfig(loss="BCELoss", weight=[1, 2, 3])
-
-    LossConfig(loss="BCELoss")
-    LossConfig(loss="BCEWithLogitsLoss", weight=None)
+    assert config.margin == 0.1
+    assert config.reduction == "sum"

--- a/tests/unittests/losses/test_config.py
+++ b/tests/unittests/losses/test_config.py
@@ -1,19 +1,18 @@
 import pytest
-import torch
 from pydantic import ValidationError
 
 from clinicadl.losses import ImplementedLoss
 from clinicadl.losses.config import (
-    BCEConfig,
-    BCEWithLogitsConfig,
-    CrossEntropyConfig,
-    HuberConfig,
-    KLDivConfig,
-    L1Config,
-    MSEConfig,
-    MultiMarginConfig,
-    NLLConfig,
-    SmoothL1Config,
+    BCELossConfig,
+    BCEWithLogitsLossConfig,
+    CrossEntropyLossConfig,
+    HuberLossConfig,
+    KLDivLossConfig,
+    L1LossConfig,
+    MSELossConfig,
+    MultiMarginLossConfig,
+    NLLLossConfig,
+    SmoothL1LossConfig,
     create_loss_config,
 )
 
@@ -21,29 +20,29 @@ from clinicadl.losses.config import (
 @pytest.mark.parametrize(
     "config,args",
     [
-        (L1Config, {"reduction": "none"}),
-        (MSEConfig, {"reduction": "none"}),
-        (CrossEntropyConfig, {"reduction": "none"}),
-        (CrossEntropyConfig, {"weight": [1, -1, 2]}),
-        (CrossEntropyConfig, {"ignore_index": -1}),
-        (CrossEntropyConfig, {"label_smoothing": 1.1}),
-        (NLLConfig, {"reduction": "none"}),
-        (NLLConfig, {"weight": [1, -1, 2]}),
-        (NLLConfig, {"ignore_index": -1}),
-        (KLDivConfig, {"reduction": "none"}),
-        (BCEConfig, {"reduction": "none"}),
-        (BCEConfig, {"weight": [0, 1]}),
-        (BCEWithLogitsConfig, {"reduction": "none"}),
-        (BCEWithLogitsConfig, {"weight": [0, 1]}),
-        (BCEWithLogitsConfig, {"pos_weight": [[1, -1, 2]]}),
-        (BCEWithLogitsConfig, {"pos_weight": [["a", "b"]]}),
-        (HuberConfig, {"reduction": "none"}),
-        (HuberConfig, {"delta": 0.0}),
-        (SmoothL1Config, {"reduction": "none"}),
-        (SmoothL1Config, {"beta": -1.0}),
-        (MultiMarginConfig, {"reduction": "none"}),
-        (MultiMarginConfig, {"p": 3}),
-        (MultiMarginConfig, {"weight": [1, -1, 2]}),
+        (L1LossConfig, {"reduction": "none"}),
+        (MSELossConfig, {"reduction": "none"}),
+        (CrossEntropyLossConfig, {"reduction": "none"}),
+        (CrossEntropyLossConfig, {"weight": [1, -1, 2]}),
+        (CrossEntropyLossConfig, {"ignore_index": -1}),
+        (CrossEntropyLossConfig, {"label_smoothing": 1.1}),
+        (NLLLossConfig, {"reduction": "none"}),
+        (NLLLossConfig, {"weight": [1, -1, 2]}),
+        (NLLLossConfig, {"ignore_index": -1}),
+        (KLDivLossConfig, {"reduction": "none"}),
+        (BCELossConfig, {"reduction": "none"}),
+        (BCELossConfig, {"weight": [0, 1]}),
+        (BCEWithLogitsLossConfig, {"reduction": "none"}),
+        (BCEWithLogitsLossConfig, {"weight": [0, 1]}),
+        (BCEWithLogitsLossConfig, {"pos_weight": [[1, -1, 2]]}),
+        (BCEWithLogitsLossConfig, {"pos_weight": [["a", "b"]]}),
+        (HuberLossConfig, {"reduction": "none"}),
+        (HuberLossConfig, {"delta": 0.0}),
+        (SmoothL1LossConfig, {"reduction": "none"}),
+        (SmoothL1LossConfig, {"beta": -1.0}),
+        (MultiMarginLossConfig, {"reduction": "none"}),
+        (MultiMarginLossConfig, {"p": 3}),
+        (MultiMarginLossConfig, {"weight": [1, -1, 2]}),
     ],
 )
 def test_validation_fail(config, args):
@@ -54,10 +53,10 @@ def test_validation_fail(config, args):
 @pytest.mark.parametrize(
     "config,args",
     [
-        (L1Config, {"reduction": "mean"}),
-        (MSEConfig, {"reduction": "mean"}),
+        (L1LossConfig, {"reduction": "mean"}),
+        (MSELossConfig, {"reduction": "mean"}),
         (
-            CrossEntropyConfig,
+            CrossEntropyLossConfig,
             {
                 "reduction": "mean",
                 "weight": [1, 0, 2],
@@ -65,17 +64,17 @@ def test_validation_fail(config, args):
                 "label_smoothing": 0.5,
             },
         ),
-        (NLLConfig, {"reduction": "mean", "weight": [1, 0, 2], "ignore_index": 1}),
-        (KLDivConfig, {"reduction": "mean", "log_target": True}),
-        (BCEConfig, {"reduction": "sum", "weight": None}),
+        (NLLLossConfig, {"reduction": "mean", "weight": [1, 0, 2], "ignore_index": 1}),
+        (KLDivLossConfig, {"reduction": "mean", "log_target": True}),
+        (BCELossConfig, {"reduction": "sum", "weight": None}),
         (
-            BCEWithLogitsConfig,
+            BCEWithLogitsLossConfig,
             {"reduction": "sum", "weight": None, "pos_weight": [[1, 0, 2]]},
         ),
-        (HuberConfig, {"reduction": "sum", "delta": 0.1}),
-        (SmoothL1Config, {"reduction": "sum", "beta": 0.0}),
+        (HuberLossConfig, {"reduction": "sum", "delta": 0.1}),
+        (SmoothL1LossConfig, {"reduction": "sum", "beta": 0.0}),
         (
-            MultiMarginConfig,
+            MultiMarginLossConfig,
             {"reduction": "sum", "p": 1, "margin": -0.1, "weight": [1, 0, 2]},
         ),
     ],
@@ -86,16 +85,20 @@ def test_validation_pass(config, args):
         assert getattr(c, arg) == value
 
 
-def test_create_loss_config():
-    for loss in ImplementedLoss:
-        create_loss_config(loss)
-
-    config_class = create_loss_config("Multi Margin")
-    config = config_class(
-        margin=0.1,
-        reduction="sum",
-    )
-    assert isinstance(config, MultiMarginConfig)
-    assert config.p == "DefaultFromLibrary"
-    assert config.margin == 0.1
-    assert config.reduction == "sum"
+@pytest.mark.parametrize(
+    "name,config",
+    [
+        ("BCELoss", BCELossConfig),
+        ("BCEWithLogitsLoss", BCEWithLogitsLossConfig),
+        ("CrossEntropyLoss", CrossEntropyLossConfig),
+        ("HuberLoss", HuberLossConfig),
+        ("KLDivLoss", KLDivLossConfig),
+        ("L1Loss", L1LossConfig),
+        ("MSELoss", MSELossConfig),
+        ("MultiMarginLoss", MultiMarginLossConfig),
+        ("NLLLoss", NLLLossConfig),
+        ("SmoothL1Loss", SmoothL1LossConfig),
+    ],
+)
+def test_create_loss_config(name, config):
+    assert create_loss_config(name) == config

--- a/tests/unittests/losses/test_config.py
+++ b/tests/unittests/losses/test_config.py
@@ -1,35 +1,101 @@
 import pytest
+import torch
 from pydantic import ValidationError
 
-from clinicadl.losses import LossConfig
+from clinicadl.losses import ImplementedLoss
+from clinicadl.losses.config import (
+    BCEConfig,
+    BCEWithLogitsConfig,
+    CrossEntropyConfig,
+    HuberConfig,
+    KLDivConfig,
+    L1Config,
+    MSEConfig,
+    MultiMarginConfig,
+    NLLConfig,
+    SmoothL1Config,
+    create_loss_config,
+)
 
 
-def test_LossConfig():
-    config = LossConfig(
-        loss="SmoothL1Loss", margin=10.0, delta=2.0, reduction="none", weight=None
+@pytest.mark.parametrize(
+    "config,args",
+    [
+        (L1Config, {"reduction": "none"}),
+        (MSEConfig, {"reduction": "none"}),
+        (CrossEntropyConfig, {"reduction": "none"}),
+        (CrossEntropyConfig, {"weight": [1, -1, 2]}),
+        (CrossEntropyConfig, {"ignore_index": -1}),
+        (CrossEntropyConfig, {"label_smoothing": 1.1}),
+        (NLLConfig, {"reduction": "none"}),
+        (NLLConfig, {"weight": [1, -1, 2]}),
+        (NLLConfig, {"ignore_index": -1}),
+        (KLDivConfig, {"reduction": "none"}),
+        (BCEConfig, {"reduction": "none"}),
+        (BCEConfig, {"weight": [0, 1]}),
+        (BCEWithLogitsConfig, {"reduction": "none"}),
+        (BCEWithLogitsConfig, {"weight": [0, 1]}),
+        (BCEWithLogitsConfig, {"pos_weight": [[1, -1, 2]]}),
+        (BCEWithLogitsConfig, {"pos_weight": [["a", "b"]]}),
+        (HuberConfig, {"reduction": "none"}),
+        (HuberConfig, {"delta": 0.0}),
+        (SmoothL1Config, {"reduction": "none"}),
+        (SmoothL1Config, {"beta": -1.0}),
+        (MultiMarginConfig, {"reduction": "none"}),
+        (MultiMarginConfig, {"p": 3}),
+        (MultiMarginConfig, {"weight": [1, -1, 2]}),
+    ],
+)
+def test_validation_fail(config, args):
+    with pytest.raises((ValidationError, ValueError)):
+        config(**args)
+
+
+@pytest.mark.parametrize(
+    "config,args",
+    [
+        (L1Config, {"reduction": "mean"}),
+        (MSEConfig, {"reduction": "mean"}),
+        (
+            CrossEntropyConfig,
+            {
+                "reduction": "mean",
+                "weight": [1, 0, 2],
+                "ignore_index": 1,
+                "label_smoothing": 0.5,
+            },
+        ),
+        (NLLConfig, {"reduction": "mean", "weight": [1, 0, 2], "ignore_index": 1}),
+        (KLDivConfig, {"reduction": "mean", "log_target": True}),
+        (BCEConfig, {"reduction": "sum", "weight": None}),
+        (
+            BCEWithLogitsConfig,
+            {"reduction": "sum", "weight": None, "pos_weight": [[1, 0, 2]]},
+        ),
+        (HuberConfig, {"reduction": "sum", "delta": 0.1}),
+        (SmoothL1Config, {"reduction": "sum", "beta": 0.0}),
+        (
+            MultiMarginConfig,
+            {"reduction": "sum", "p": 1, "margin": -0.1, "weight": [1, 0, 2]},
+        ),
+    ],
+)
+def test_validation_pass(config, args):
+    c = config(**args)
+    for arg, value in args.items():
+        assert getattr(c, arg) == value
+
+
+def test_create_loss_config():
+    for loss in ImplementedLoss:
+        create_loss_config(loss)
+
+    config_class = create_loss_config("Multi Margin")
+    config = config_class(
+        margin=0.1,
+        reduction="sum",
     )
-    assert config.loss == "SmoothL1Loss"
-    assert config.margin == 10.0
-    assert config.delta == 2.0
-    assert config.reduction == "none"
+    assert isinstance(config, MultiMarginConfig)
     assert config.p == "DefaultFromLibrary"
-
-    with pytest.raises(ValueError):
-        LossConfig(loss="abc")
-    with pytest.raises(ValueError):
-        LossConfig(weight=[0.1, -0.1, 0.8])
-    with pytest.raises(ValueError):
-        LossConfig(p=3)
-    with pytest.raises(ValueError):
-        LossConfig(reduction="abc")
-    with pytest.raises(ValidationError):
-        LossConfig(label_smoothing=1.1)
-    with pytest.raises(ValidationError):
-        LossConfig(ignore_index=-1)
-    with pytest.raises(ValidationError):
-        LossConfig(loss="BCEWithLogitsLoss", weight=[1, 2, 3])
-    with pytest.raises(ValidationError):
-        LossConfig(loss="BCELoss", weight=[1, 2, 3])
-
-    LossConfig(loss="BCELoss")
-    LossConfig(loss="BCEWithLogitsLoss", weight=None)
+    assert config.margin == 0.1
+    assert config.reduction == "sum"

--- a/tests/unittests/losses/test_factory.py
+++ b/tests/unittests/losses/test_factory.py
@@ -1,15 +1,15 @@
 from torch import Tensor
 from torch.nn import BCEWithLogitsLoss, MultiMarginLoss
 
-from clinicadl.losses import ImplementedLoss, LossConfig, get_loss_function
+from clinicadl.losses import ImplementedLoss, create_loss_config, get_loss_function
 
 
 def test_get_loss_function():
-    for loss in [e.value for e in ImplementedLoss]:
-        config = LossConfig(loss=loss)
-        get_loss_function(config)
+    for loss in ImplementedLoss:
+        config = create_loss_config(loss=loss)()
+        _ = get_loss_function(config)
 
-    config = LossConfig(loss="MultiMarginLoss", reduction="sum", weight=[1, 2, 3], p=2)
+    config = create_loss_config("Multi Margin")(reduction="sum", weight=[1, 2, 3], p=2)
     loss, updated_config = get_loss_function(config)
     assert isinstance(loss, MultiMarginLoss)
     assert loss.reduction == "sum"
@@ -23,7 +23,7 @@ def test_get_loss_function():
     assert updated_config.margin == 1.0
     assert updated_config.weight == [1, 2, 3]
 
-    config = LossConfig(loss="BCEWithLogitsLoss", pos_weight=[1, 2, 3])
+    config = create_loss_config("BCE With Logits")(pos_weight=[1, 2, 3])
     loss, updated_config = get_loss_function(config)
     assert isinstance(loss, BCEWithLogitsLoss)
     assert (loss.pos_weight == Tensor([1, 2, 3])).all()

--- a/tests/unittests/losses/test_factory.py
+++ b/tests/unittests/losses/test_factory.py
@@ -9,7 +9,9 @@ def test_get_loss_function():
         config = create_loss_config(loss=loss)()
         _ = get_loss_function(config)
 
-    config = create_loss_config("Multi Margin")(reduction="sum", weight=[1, 2, 3], p=2)
+    config = create_loss_config("MultiMarginLoss")(
+        reduction="sum", weight=[1, 2, 3], p=2
+    )
     loss, updated_config = get_loss_function(config)
     assert isinstance(loss, MultiMarginLoss)
     assert loss.reduction == "sum"
@@ -23,7 +25,7 @@ def test_get_loss_function():
     assert updated_config.margin == 1.0
     assert updated_config.weight == [1, 2, 3]
 
-    config = create_loss_config("BCE With Logits")(pos_weight=[1, 2, 3])
+    config = create_loss_config("BCEWithLogitsLoss")(pos_weight=[1, 2, 3])
     loss, updated_config = get_loss_function(config)
     assert isinstance(loss, BCEWithLogitsLoss)
     assert (loss.pos_weight == Tensor([1, 2, 3])).all()


### PR DESCRIPTION
This PR is a review of the loss function module created in #640. 

More precisely, I created one config class for each supported loss function, whereas before there was a single config class for all the losses. This enables to create a `create_loss_config` function that is similar to `create_network_config` (see #647) and `create_metric_config` (see #654), and therefore have a consistent behavior across all modules.

I also put all the `Enum` class in a specific file.