### PR TITLE
Review optim module

### DIFF
--- a/clinicadl/optim/__init__.py
+++ b/clinicadl/optim/__init__.py
@@ -1,1 +1,4 @@
 from .config import OptimizationConfig
+from .early_stopping import EarlyStopping
+from .lr_scheduler import create_lr_scheduler_config, get_lr_scheduler
+from .optimizer import create_optimizer_config, get_optimizer

--- a/clinicadl/optim/lr_scheduler/__init__.py
+++ b/clinicadl/optim/lr_scheduler/__init__.py
@@ -1,2 +1,3 @@
-from .config import ImplementedLRScheduler, LRSchedulerConfig
+from .config import create_lr_scheduler_config
+from .enum import ImplementedLRScheduler
 from .factory import get_lr_scheduler

--- a/clinicadl/optim/lr_scheduler/config.py
+++ b/clinicadl/optim/lr_scheduler/config.py
@@ -1,7 +1,4 @@
-from __future__ import annotations
-
-from enum import Enum
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Type, Union
 
 from pydantic import (
     BaseModel,
@@ -10,70 +7,42 @@ from pydantic import (
     NonNegativeInt,
     PositiveFloat,
     PositiveInt,
+    computed_field,
     field_validator,
-    model_validator,
 )
 
 from clinicadl.utils.factories import DefaultFromLibrary
 
+from .enum import ImplementedLRScheduler, Mode, ThresholdMode
 
-class ImplementedLRScheduler(str, Enum):
-    """Implemented LR schedulers in ClinicaDL."""
-
-    CONSTANT = "ConstantLR"
-    LINEAR = "LinearLR"
-    STEP = "StepLR"
-    MULTI_STEP = "MultiStepLR"
-    PLATEAU = "ReduceLROnPlateau"
-
-    @classmethod
-    def _missing_(cls, value):
-        raise ValueError(
-            f"{value} is not implemented. Implemented LR schedulers are: "
-            + ", ".join([repr(m.value) for m in cls])
-        )
-
-
-class Mode(str, Enum):
-    """Supported mode for ReduceLROnPlateau."""
-
-    MIN = "min"
-    MAX = "max"
-
-
-class ThresholdMode(str, Enum):
-    """Supported threshold mode for ReduceLROnPlateau."""
-
-    ABS = "abs"
-    REL = "rel"
+__all__ = [
+    "LRSchedulerConfig",
+    "ConstantLRConfig",
+    "LinearLRConfig",
+    "StepLRConfig",
+    "MultiStepLRConfig",
+    "ReduceLROnPlateauConfig",
+    "create_lr_scheduler_config",
+]
 
 
 class LRSchedulerConfig(BaseModel):
-    """Config class to configure the optimizer."""
+    """Base config class for the LR scheduler."""
 
-    scheduler: Optional[ImplementedLRScheduler] = None
-    step_size: Optional[PositiveInt] = None
     gamma: Union[PositiveFloat, DefaultFromLibrary] = DefaultFromLibrary.YES
-    milestones: Optional[List[PositiveInt]] = None
     factor: Union[PositiveFloat, DefaultFromLibrary] = DefaultFromLibrary.YES
-    start_factor: Union[PositiveFloat, DefaultFromLibrary] = DefaultFromLibrary.YES
-    end_factor: Union[PositiveFloat, DefaultFromLibrary] = DefaultFromLibrary.YES
     total_iters: Union[PositiveInt, DefaultFromLibrary] = DefaultFromLibrary.YES
     last_epoch: Union[int, DefaultFromLibrary] = DefaultFromLibrary.YES
-
-    mode: Union[Mode, DefaultFromLibrary] = DefaultFromLibrary.YES
-    patience: Union[PositiveInt, DefaultFromLibrary] = DefaultFromLibrary.YES
-    threshold: Union[NonNegativeFloat, DefaultFromLibrary] = DefaultFromLibrary.YES
-    threshold_mode: Union[ThresholdMode, DefaultFromLibrary] = DefaultFromLibrary.YES
-    cooldown: Union[NonNegativeInt, DefaultFromLibrary] = DefaultFromLibrary.YES
-    min_lr: Union[
-        NonNegativeFloat, Dict[str, PositiveFloat], DefaultFromLibrary
-    ] = DefaultFromLibrary.YES
-    eps: Union[NonNegativeFloat, DefaultFromLibrary] = DefaultFromLibrary.YES
     # pydantic config
     model_config = ConfigDict(
         validate_assignment=True, use_enum_values=True, validate_default=True
     )
+
+    @computed_field
+    @property
+    def scheduler(self) -> Optional[ImplementedLRScheduler]:
+        """The name of the scheduler."""
+        return None
 
     @field_validator("last_epoch")
     @classmethod
@@ -84,31 +53,108 @@ class LRSchedulerConfig(BaseModel):
             ), f"last_epoch must be -1 or a non-negative int but it has been set to {v}."
         return v
 
-    @field_validator("milestones")
+
+class ConstantLRConfig(LRSchedulerConfig):
+    """Config class for ConstantLR scheduler."""
+
+    @computed_field
+    @property
+    def scheduler(self) -> ImplementedLRScheduler:
+        """The name of the scheduler."""
+        return ImplementedLRScheduler.CONSTANT
+
+
+class LinearLRConfig(LRSchedulerConfig):
+    """Config class for LinearLR scheduler."""
+
+    start_factor: Union[PositiveFloat, DefaultFromLibrary] = DefaultFromLibrary.YES
+    end_factor: Union[PositiveFloat, DefaultFromLibrary] = DefaultFromLibrary.YES
+
+    @computed_field
+    @property
+    def scheduler(self) -> ImplementedLRScheduler:
+        """The name of the scheduler."""
+        return ImplementedLRScheduler.LINEAR
+
+
+class StepLRConfig(LRSchedulerConfig):
+    """Config class for StepLR scheduler."""
+
+    step_size: PositiveInt
+
+    @computed_field
+    @property
+    def scheduler(self) -> ImplementedLRScheduler:
+        """The name of the scheduler."""
+        return ImplementedLRScheduler.STEP
+
+
+class MultiStepLRConfig(LRSchedulerConfig):
+    """Config class for MultiStepLR scheduler."""
+
+    milestones: List[PositiveInt]
+
+    @computed_field
+    @property
+    def scheduler(self) -> ImplementedLRScheduler:
+        """The name of the scheduler."""
+        return ImplementedLRScheduler.MULTI_STEP
+
+    @field_validator("milestones", mode="after")
     @classmethod
     def validator_milestones(cls, v):
         import numpy as np
 
-        if v is not None:
-            assert len(np.unique(v)) == len(
-                v
-            ), "Epoch(s) in milestones should be unique."
-            return sorted(v)
-        return v
+        assert len(np.unique(v)) == len(v), "Epoch(s) in milestones should be unique."
+        return sorted(v)
 
-    @model_validator(mode="after")
-    def check_mandatory_args(self) -> LRSchedulerConfig:
-        if (
-            self.scheduler == ImplementedLRScheduler.MULTI_STEP
-            and self.milestones is None
-        ):
-            raise ValueError(
-                """If you chose MultiStepLR as LR scheduler, you should pass milestones
-                (see PyTorch documentation for more details)."""
-            )
-        elif self.scheduler == ImplementedLRScheduler.STEP and self.step_size is None:
-            raise ValueError(
-                """If you chose StepLR as LR scheduler, you should pass a step_size
-                (see PyTorch documentation for more details)."""
-            )
-        return self
+
+class ReduceLROnPlateauConfig(LRSchedulerConfig):
+    """Config class for ReduceLROnPlateau scheduler."""
+
+    mode: Union[Mode, DefaultFromLibrary] = DefaultFromLibrary.YES
+    patience: Union[PositiveInt, DefaultFromLibrary] = DefaultFromLibrary.YES
+    threshold: Union[NonNegativeFloat, DefaultFromLibrary] = DefaultFromLibrary.YES
+    threshold_mode: Union[ThresholdMode, DefaultFromLibrary] = DefaultFromLibrary.YES
+    cooldown: Union[NonNegativeInt, DefaultFromLibrary] = DefaultFromLibrary.YES
+    min_lr: Union[
+        NonNegativeFloat, Dict[str, NonNegativeFloat], DefaultFromLibrary
+    ] = DefaultFromLibrary.YES
+    eps: Union[NonNegativeFloat, DefaultFromLibrary] = DefaultFromLibrary.YES
+
+    @property
+    def scheduler(self) -> ImplementedLRScheduler:
+        """The name of the scheduler."""
+        return ImplementedLRScheduler.PLATEAU
+
+
+def create_lr_scheduler_config(
+    scheduler: Optional[Union[str, ImplementedLRScheduler]],
+) -> Type[LRSchedulerConfig]:
+    """
+    A factory function to create a config class suited for the LR scheduler.
+
+    Parameters
+    ----------
+    scheduler : Optional[Union[str, ImplementedLRScheduler]]
+        The name of the LR scheduler.
+        Can be None if no LR scheduler will be used.
+
+    Returns
+    -------
+    Type[LRSchedulerConfig]
+        The config class.
+
+    Raises
+    ------
+    ValueError
+        If `scheduler` is not supported.
+    """
+    if scheduler is None:
+        return LRSchedulerConfig
+
+    scheduler = ImplementedLRScheduler(scheduler)
+    config_name = "".join([scheduler, "Config"])
+    config = globals()[config_name]
+
+    return config

--- a/clinicadl/optim/lr_scheduler/enum.py
+++ b/clinicadl/optim/lr_scheduler/enum.py
@@ -1,0 +1,32 @@
+from enum import Enum
+
+
+class ImplementedLRScheduler(str, Enum):
+    """Implemented LR schedulers in ClinicaDL."""
+
+    CONSTANT = "ConstantLR"
+    LINEAR = "LinearLR"
+    STEP = "StepLR"
+    MULTI_STEP = "MultiStepLR"
+    PLATEAU = "ReduceLROnPlateau"
+
+    @classmethod
+    def _missing_(cls, value):
+        raise ValueError(
+            f"{value} is not implemented. Implemented LR schedulers are: "
+            + ", ".join([repr(m.value) for m in cls])
+        )
+
+
+class Mode(str, Enum):
+    """Supported mode for ReduceLROnPlateau."""
+
+    MIN = "min"
+    MAX = "max"
+
+
+class ThresholdMode(str, Enum):
+    """Supported threshold mode for ReduceLROnPlateau."""
+
+    ABS = "abs"
+    REL = "rel"

--- a/clinicadl/optim/lr_scheduler/factory.py
+++ b/clinicadl/optim/lr_scheduler/factory.py
@@ -51,6 +51,6 @@ def get_lr_scheduler(
             )  # ELSE must be the last group
     scheduler = scheduler_class(optimizer, **config_dict_)
 
-    updated_config = LRSchedulerConfig(scheduler=config.scheduler, **config_dict)
+    updated_config = config.model_copy(update=config_dict)
 
     return scheduler, updated_config

--- a/clinicadl/optim/optimizer/__init__.py
+++ b/clinicadl/optim/optimizer/__init__.py
@@ -1,2 +1,3 @@
-from .config import ImplementedOptimizer, OptimizerConfig
+from .config import create_optimizer_config
+from .enum import ImplementedOptimizer
 from .factory import get_optimizer

--- a/clinicadl/optim/optimizer/enum.py
+++ b/clinicadl/optim/optimizer/enum.py
@@ -1,0 +1,18 @@
+from enum import Enum
+
+
+class ImplementedOptimizer(str, Enum):
+    """Implemented optimizers in ClinicaDL."""
+
+    ADADELTA = "Adadelta"
+    ADAGRAD = "Adagrad"
+    ADAM = "Adam"
+    RMS_PROP = "RMSprop"
+    SGD = "SGD"
+
+    @classmethod
+    def _missing_(cls, value):
+        raise ValueError(
+            f"{value} is not implemented. Implemented optimizers are: "
+            + ", ".join([repr(m.value) for m in cls])
+        )

--- a/clinicadl/optim/optimizer/factory.py
+++ b/clinicadl/optim/optimizer/factory.py
@@ -1,5 +1,6 @@
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Iterable, Iterator, List, Tuple
 
+import torch
 import torch.nn as nn
 import torch.optim as optim
 

--- a/tests/unittests/optim/lr_scheduler/test_config.py
+++ b/tests/unittests/optim/lr_scheduler/test_config.py
@@ -1,37 +1,114 @@
 import pytest
 from pydantic import ValidationError
 
-from clinicadl.optim.lr_scheduler import LRSchedulerConfig
+from clinicadl.optim.lr_scheduler.config import (
+    ConstantLRConfig,
+    LinearLRConfig,
+    MultiStepLRConfig,
+    ReduceLROnPlateauConfig,
+    StepLRConfig,
+    create_lr_scheduler_config,
+)
+
+BAD_INPUTS = {
+    "milestones": [3, 2, 4],
+    "gamma": 0,
+    "last_epoch": -2,
+    "step_size": 0,
+    "factor": 0,
+    "total_iters": 0,
+    "start_factor": 0,
+    "end_factor": 0,
+    "mode": "abc",
+    "patience": 0,
+    "threshold": -1,
+    "threshold_mode": "abc",
+    "cooldown": -1,
+    "eps": -0.1,
+    "min_lr": -0.1,
+}
+
+GOOD_INPUTS = {
+    "milestones": [1, 4, 5],
+    "gamma": 0.1,
+    "last_epoch": -1,
+    "step_size": 1,
+    "factor": 0.1,
+    "total_iters": 1,
+    "start_factor": 0.1,
+    "end_factor": 0.2,
+    "mode": "min",
+    "patience": 1,
+    "threshold": 0,
+    "threshold_mode": "abs",
+    "cooldown": 0,
+    "eps": 0,
+    "min_lr": 0,
+}
 
 
-def test_LRSchedulerConfig():
-    config = LRSchedulerConfig(
-        scheduler="ReduceLROnPlateau",
-        mode="max",
-        patience=1,
-        threshold_mode="rel",
-        milestones=[4, 3, 2],
-        min_lr={"param_0": 1e-1, "ELSE": 1e-2},
-    )
-    assert config.scheduler == "ReduceLROnPlateau"
-    assert config.mode == "max"
-    assert config.patience == 1
-    assert config.threshold_mode == "rel"
-    assert config.milestones == [2, 3, 4]
-    assert config.min_lr == {"param_0": 1e-1, "ELSE": 1e-2}
-    assert config.threshold == "DefaultFromLibrary"
+@pytest.mark.parametrize(
+    "config",
+    [
+        ConstantLRConfig,
+        LinearLRConfig,
+        MultiStepLRConfig,
+        ReduceLROnPlateauConfig,
+        StepLRConfig,
+    ],
+)
+def test_validation_fail(config):
+    fields = config.model_fields
+    inputs = {key: value for key, value in BAD_INPUTS.items() if key in fields}
+    with pytest.raises(ValidationError):
+        config(**inputs)
 
+    # test dict inputs for min_lr
+    if "min_lr" in inputs:
+        inputs["min_lr"] = {"group_1": inputs["min_lr"]}
+        with pytest.raises(ValidationError):
+            config(**inputs)
+
+
+def test_validation_fail_special():
     with pytest.raises(ValidationError):
-        LRSchedulerConfig(last_epoch=-2)
-    with pytest.raises(ValueError):
-        LRSchedulerConfig(scheduler="abc")
-    with pytest.raises(ValueError):
-        LRSchedulerConfig(mode="abc")
-    with pytest.raises(ValueError):
-        LRSchedulerConfig(threshold_mode="abc")
-    with pytest.raises(ValidationError):
-        LRSchedulerConfig(milestones=[10, 10])
-    with pytest.raises(ValidationError):
-        LRSchedulerConfig(scheduler="MultiStepLR")
-    with pytest.raises(ValidationError):
-        LRSchedulerConfig(scheduler="StepLR")
+        MultiStepLRConfig(milestones=[0, 1])
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        ConstantLRConfig,
+        LinearLRConfig,
+        MultiStepLRConfig,
+        ReduceLROnPlateauConfig,
+        StepLRConfig,
+    ],
+)
+def test_validation_pass(config):
+    fields = config.model_fields
+    inputs = {key: value for key, value in GOOD_INPUTS.items() if key in fields}
+    c = config(**inputs)
+    for arg, value in inputs.items():
+        assert getattr(c, arg) == value
+
+    # test dict inputs
+    if "min_lr" in inputs:
+        inputs["min_lr"] = {"group_1": inputs["min_lr"]}
+        c = config(**inputs)
+        assert getattr(c, "min_lr") == inputs["min_lr"]
+
+
+@pytest.mark.parametrize(
+    "name,expected_class",
+    [
+        ("ConstantLR", ConstantLRConfig),
+        ("LinearLR", LinearLRConfig),
+        ("MultiStepLR", MultiStepLRConfig),
+        ("ReduceLROnPlateau", ReduceLROnPlateauConfig),
+        ("StepLR", StepLRConfig),
+    ],
+)
+def test_create_optimizer_config(name, expected_class):
+    config = create_lr_scheduler_config(name)
+    assert config == expected_class

--- a/tests/unittests/optim/lr_scheduler/test_factory.py
+++ b/tests/unittests/optim/lr_scheduler/test_factory.py
@@ -6,7 +6,7 @@ from torch.optim.lr_scheduler import LambdaLR, ReduceLROnPlateau
 
 from clinicadl.optim.lr_scheduler import (
     ImplementedLRScheduler,
-    LRSchedulerConfig,
+    create_lr_scheduler_config,
     get_lr_scheduler,
 )
 
@@ -33,17 +33,12 @@ def test_get_lr_scheduler():
         lr=10.0,
     )
 
-    for scheduler in [e.value for e in ImplementedLRScheduler]:
-        if scheduler == "StepLR":
-            config = LRSchedulerConfig(scheduler=scheduler, step_size=1)
-        elif scheduler == "MultiStepLR":
-            config = LRSchedulerConfig(scheduler=scheduler, milestones=[1, 2, 3])
-        else:
-            config = LRSchedulerConfig(scheduler=scheduler)
-        get_lr_scheduler(optimizer, config)
+    args = {"step_size": 1, "milestones": [1, 2]}
+    for scheduler in ImplementedLRScheduler:
+        config = create_lr_scheduler_config(scheduler=scheduler)(**args)
+        _ = get_lr_scheduler(optimizer, config)
 
-    config = LRSchedulerConfig(
-        scheduler="ReduceLROnPlateau",
+    config = create_lr_scheduler_config(scheduler="ReduceLROnPlateau")(
         mode="max",
         factor=0.123,
         threshold=1e-1,
@@ -77,7 +72,8 @@ def test_get_lr_scheduler():
     scheduler, updated_config = get_lr_scheduler(optimizer, config)
     assert scheduler.min_lrs == [0.1, 0.01, 1]
 
-    config = LRSchedulerConfig()
+    # no lr scheduler
+    config = create_lr_scheduler_config(None)()
     scheduler, updated_config = get_lr_scheduler(optimizer, config)
     assert isinstance(scheduler, LambdaLR)
     assert updated_config.scheduler is None

--- a/tests/unittests/optim/optimizer/test_config.py
+++ b/tests/unittests/optim/optimizer/test_config.py
@@ -1,5 +1,4 @@
 import pytest
-import torch
 from pydantic import ValidationError
 
 from clinicadl.optim.optimizer.config import (

--- a/tests/unittests/optim/optimizer/test_config.py
+++ b/tests/unittests/optim/optimizer/test_config.py
@@ -1,34 +1,119 @@
 import pytest
+import torch
 from pydantic import ValidationError
 
-from clinicadl.optim.optimizer import OptimizerConfig
+from clinicadl.optim.optimizer.config import (
+    AdadeltaConfig,
+    AdagradConfig,
+    AdamConfig,
+    RMSpropConfig,
+    SGDConfig,
+    create_optimizer_config,
+)
+
+BAD_INPUTS = {
+    "lr": 0,
+    "rho": 1.1,
+    "eps": -0.1,
+    "weight_decay": -0.1,
+    "lr_decay": -0.1,
+    "initial_accumulator_value": -0.1,
+    "betas": (0.9, 1.0),
+    "alpha": 1.1,
+    "momentum": -0.1,
+    "dampening": 0.1,
+}
+
+GOOD_INPUTS_1 = {
+    "lr": 0.1,
+    "rho": 0,
+    "eps": 0,
+    "weight_decay": 0,
+    "foreach": None,
+    "capturable": False,
+    "maximize": True,
+    "differentiable": False,
+    "fused": None,
+    "lr_decay": 0,
+    "initial_accumulator_value": 0,
+    "betas": (0.0, 0.0),
+    "amsgrad": True,
+    "alpha": 0.0,
+    "momentum": 0,
+    "centered": True,
+    "dampening": 0,
+    "nesterov": True,
+}
+
+GOOD_INPUTS_2 = {
+    "foreach": True,
+    "fused": False,
+}
 
 
-def test_OptimizerConfig():
-    config = OptimizerConfig(
-        optimizer="SGD",
-        lr=1e-3,
-        weight_decay={"param_0": 1e-3, "param_1": 1e-2},
-        momentum={"param_1": 1e-1},
-        lr_decay=1e-4,
-    )
-    assert config.optimizer == "SGD"
-    assert config.lr == 1e-3
-    assert config.weight_decay == {"param_0": 1e-3, "param_1": 1e-2}
-    assert config.momentum == {"param_1": 1e-1}
-    assert config.lr_decay == 1e-4
-    assert config.alpha == "DefaultFromLibrary"
-    assert sorted(config.get_all_groups()) == ["param_0", "param_1"]
+@pytest.mark.parametrize(
+    "config",
+    [
+        AdadeltaConfig,
+        AdagradConfig,
+        AdamConfig,
+        RMSpropConfig,
+        SGDConfig,
+    ],
+)
+def test_validation_fail(config):
+    fields = config.model_fields
+    inputs = {key: value for key, value in BAD_INPUTS.items() if key in fields}
+    with pytest.raises(ValidationError):
+        config(**inputs)
 
+    # test dict inputs
+    inputs = {key: {"group_1": value} for key, value in inputs.items()}
     with pytest.raises(ValidationError):
-        OptimizerConfig(betas={"params_0": (0.9, 1.01), "params_1": (0.9, 0.99)})
-    with pytest.raises(ValidationError):
-        OptimizerConfig(betas=0.9)
-    with pytest.raises(ValidationError):
-        OptimizerConfig(rho=1.01)
-    with pytest.raises(ValidationError):
-        OptimizerConfig(alpha=1.01)
-    with pytest.raises(ValidationError):
-        OptimizerConfig(dampening={"params_0": 0.1, "params_1": 2})
-    with pytest.raises(ValueError):
-        OptimizerConfig(optimizer="abc")
+        config(**inputs)
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        AdadeltaConfig,
+        AdagradConfig,
+        AdamConfig,
+        RMSpropConfig,
+        SGDConfig,
+    ],
+)
+@pytest.mark.parametrize(
+    "good_inputs",
+    [
+        GOOD_INPUTS_1,
+        GOOD_INPUTS_2,
+    ],
+)
+def test_validation_pass(config, good_inputs):
+    fields = config.model_fields
+    inputs = {key: value for key, value in good_inputs.items() if key in fields}
+    c = config(**inputs)
+    for arg, value in inputs.items():
+        assert getattr(c, arg) == value
+
+    # test dict inputs
+    inputs = {key: {"group_1": value} for key, value in inputs.items()}
+    c = config(**inputs)
+    for arg, value in inputs.items():
+        assert getattr(c, arg) == value
+
+
+@pytest.mark.parametrize(
+    "name,expected_class",
+    [
+        ("Adadelta", AdadeltaConfig),
+        ("Adagrad", AdagradConfig),
+        ("Adam", AdamConfig),
+        ("RMSprop", RMSpropConfig),
+        ("SGD", SGDConfig),
+    ],
+)
+def test_create_optimizer_config(name, expected_class):
+    config = create_optimizer_config(name)
+    assert config == expected_class

--- a/tests/unittests/optim/optimizer/test_factory.py
+++ b/tests/unittests/optim/optimizer/test_factory.py
@@ -1,12 +1,25 @@
 from collections import OrderedDict
 
 import pytest
+import torch
 import torch.nn as nn
+from torch.optim import Adagrad
+
+from clinicadl.optim.optimizer import (
+    ImplementedOptimizer,
+    create_optimizer_config,
+    get_optimizer,
+)
+from clinicadl.optim.optimizer.factory import (
+    _get_params_in_group,
+    _get_params_not_in_group,
+    _regroup_args,
+)
 
 
 @pytest.fixture
 def network():
-    network = nn.Sequential(
+    net = nn.Sequential(
         OrderedDict(
             [
                 ("conv1", nn.Conv2d(1, 1, kernel_size=3)),
@@ -14,31 +27,22 @@ def network():
             ]
         )
     )
-    network.add_module(
+    net.add_module(
         "final",
         nn.Sequential(
             OrderedDict([("dense2", nn.Linear(10, 5)), ("dense3", nn.Linear(5, 3))])
         ),
     )
-    return network
+    return net
 
 
 def test_get_optimizer(network):
-    from torch.optim import Adagrad
-
-    from clinicadl.optim.optimizer import (
-        ImplementedOptimizer,
-        OptimizerConfig,
-        get_optimizer,
-    )
-
-    for optimizer in [e.value for e in ImplementedOptimizer]:
-        config = OptimizerConfig(optimizer=optimizer)
+    for optimizer in ImplementedOptimizer:
+        config = create_optimizer_config(optimizer=optimizer)()
         optimizer, _ = get_optimizer(network, config)
         assert len(optimizer.param_groups) == 1
 
-    config = OptimizerConfig(
-        optimizer="Adagrad",
+    config = create_optimizer_config("Adagrad")(
         lr=1e-5,
         weight_decay={"final.dense3.weight": 1.0, "dense1": 0.1},
         lr_decay={"dense1": 10, "ELSE": 100},
@@ -82,17 +86,16 @@ def test_get_optimizer(network):
     assert not updated_config.maximize
     assert not updated_config.differentiable
 
-    # special cases
-    config = OptimizerConfig(
-        optimizer="Adagrad",
+    # special cases 1
+    config = create_optimizer_config("Adagrad")(
         lr_decay={"ELSE": 100},
     )
     optimizer, _ = get_optimizer(network, config)
     assert len(optimizer.param_groups) == 1
     assert optimizer.param_groups[0]["lr_decay"] == 100
 
-    config = OptimizerConfig(
-        optimizer="Adagrad",
+    # special cases 2
+    config = create_optimizer_config("Adagrad")(
         lr_decay={"conv1": 100, "dense1": 10, "final": 1},
     )
     optimizer, _ = get_optimizer(network, config)
@@ -100,8 +103,6 @@ def test_get_optimizer(network):
 
 
 def test_regroup_args():
-    from clinicadl.optim.optimizer.factory import _regroup_args
-
     args = {
         "weight_decay": {"params_0": 0.0, "params_1": 1.0},
         "alpha": {"params_1": 0.5, "ELSE": 0.1},
@@ -126,10 +127,6 @@ def test_regroup_args():
 
 
 def test_get_params_in_block(network):
-    import torch
-
-    from clinicadl.optim.optimizer.factory import _get_params_in_group
-
     generator, list_layers = _get_params_in_group(network, "dense1")
     assert next(iter(generator)).shape == torch.Size((10, 10))
     assert next(iter(generator)).shape == torch.Size((10,))
@@ -158,10 +155,6 @@ def test_get_params_in_block(network):
 
 
 def test_find_params_not_in_group(network):
-    import torch
-
-    from clinicadl.optim.optimizer.factory import _get_params_not_in_group
-
     params = _get_params_not_in_group(
         network,
         [

--- a/tests/unittests/optim/optimizer/test_factory.py
+++ b/tests/unittests/optim/optimizer/test_factory.py
@@ -102,10 +102,7 @@ def test_get_optimizer(network):
     assert len(optimizer.param_groups) == 3
 
     # special case : no ELSE mentioned
-    config = OptimizerConfig(
-        optimizer="Adagrad",
-        lr_decay={"conv1": 100},
-    )
+    config = create_optimizer_config("Adagrad")(lr_decay={"conv1": 100})
     optimizer, _ = get_optimizer(network, config)
     assert len(optimizer.param_groups) == 2
     assert optimizer.param_groups[0]["lr_decay"] == 100


### PR DESCRIPTION
This PR is a review of the optim module created in #643 . 

More precisely, I created one config class for each supported optimizer and LR scheduler, whereas before there was a single config class for all the optimizers and one for all the schedulers. This enables to create `create_optimizer_config` and `create_lr_scheduler_config` functions that are similar to `create_network_config` (see #647), `create_metric_config` (see #654) and `create_loss_config` (see #655) and therefore have a consistent behavior across all modules.

I also put all the `Enum` class in specific files.