### PR TITLE
Overwrite argument in ``to_tensors``

### DIFF
--- a/clinicadl/data/datasets/caps_dataset.py
+++ b/clinicadl/data/datasets/caps_dataset.py
@@ -343,6 +343,7 @@ class CapsDataset(Dataset):
         ignore_spacing: bool = False,
         shape_warning: bool = True,
         conversion_name: Optional[str] = None,
+        overwrite: bool = False,
         save_transforms: bool = False,
         check_transforms: bool = True,
     ) -> None:
@@ -393,9 +394,12 @@ class CapsDataset(Dataset):
             - the name of the ``json`` file that will store information on the conversion:
               ``{caps_directory}/tensor_conversion/{conversion_name}.json``.
 
-            If a conversion with this name already exists, ``ClinicaDL`` will try to merge the old
-            tensor conversion with the new one if they concern the same type of data (same
-            preprocessing, same transforms applied, etc.), otherwise an error will be raised.
+            If a conversion with this name already exists:
+
+            - if ``overwrite=True``, ``CapsDataset`` will overwrite the old conversion and the associated
+              tensors;
+            - else, ``CapsDataset`` will try to merge the old tensor conversion with the new one if they
+              concern the same type of data (same preprocessing, same transforms applied, etc.), otherwise an error will be raised.
 
             If ``None``, the tensors will be saved in ``{caps_directory}/subjects/sub-*/ses-*/{preprocessing}/tensors/default``,
             and the name of the ``json`` file will be inferred, depending on the preprocessing, but will always start with
@@ -405,13 +409,16 @@ class CapsDataset(Dataset):
 
             ``conversion_name`` **cannot** be ``None`` if ``save_transforms=True``.
 
+        overwrite : bool, default=False
+            Whether to overwrite an old tensor conversion that as the same ``conversion_name``.
+
         save_transforms : bool, default=False
             Whether to save raw images as tensors (``False``), or images on which were applied image
             transforms (``True``). Saving transformed images will speed up dataloading. However transformed
             images are specific to a sequence of transforms, so they cannot be used by any future ``CapsDataset``.
 
         check_transforms : bool, default=True
-            If a conversion named ``conversion_name`` already exists, the ``CapsDataset`` will try to merge the current
+            If a conversion named ``conversion_name`` already exists and ``overwrite=False``, the ``CapsDataset`` will try to merge the current
             tensor conversion with the old one. ``check_transforms`` determines whether transforms
             will be checked during the merger. If ``True``, ``CapsDataset`` will check that current transforms match
             the transforms applied during the old conversions.\n
@@ -539,6 +546,7 @@ class CapsDataset(Dataset):
             ignore_spacing=ignore_spacing,
             shape_warning=shape_warning,
             conversion_name=conversion_name,
+            overwrite=overwrite,
             save_transforms=save_transforms,
             check_transforms=check_transforms,
         )

--- a/clinicadl/data/tensor_conversion.py
+++ b/clinicadl/data/tensor_conversion.py
@@ -14,7 +14,7 @@ from joblib import Parallel, delayed
 from pydantic import SerializeAsAny, ValidationError, field_serializer
 from tqdm import tqdm
 
-from clinicadl.dictionary.suffixes import JSON, PT
+from clinicadl.dictionary.suffixes import JSON
 from clinicadl.dictionary.words import (
     AFFINE,
     DEFAULT,
@@ -35,7 +35,10 @@ from clinicadl.utils.exceptions import (
     ClinicaDLTensorConversionError,
 )
 
-from .datatypes.preprocessing import Preprocessing, get_preprocessing_config
+from .datatypes.preprocessing import (
+    Preprocessing,
+    get_preprocessing_config,
+)
 from .structures import DataPoint, Mask
 
 if TYPE_CHECKING:
@@ -229,6 +232,7 @@ class TensorConversion:
         ignore_spacing: bool = False,
         shape_warning: bool = True,
         conversion_name: Optional[str] = None,
+        overwrite: bool = False,
         save_transforms: bool = False,
         check_transforms: bool = True,
     ) -> None:
@@ -243,9 +247,16 @@ class TensorConversion:
         self._ignore_spacing = ignore_spacing
         self._shape_warning = shape_warning
 
-        self.json = conversion_name
+        self.json: Path = conversion_name
         self.tensor_folder_name = conversion_name
-        self._merge_with_old_conversions(check_transforms=check_transforms)
+        if self.json.is_file() and overwrite:
+            from .utils import remove_tensors
+
+            remove_tensors(
+                self.caps_reader.input_directory, conversion_name=self.json.stem
+            )
+        elif self.json.is_file():
+            self._merge_with_old_conversion(check_transforms=check_transforms)
 
         # process images and masks, and manage errors
         try:
@@ -620,23 +631,21 @@ class TensorConversion:
                 f"{self.json} does not exist, please give a valid 'conversion_name'."
             )
 
-    def _merge_with_old_conversions(self, check_transforms: bool = True) -> None:
+    def _merge_with_old_conversion(self, check_transforms: bool = True) -> None:
         """
-        Checks if a conversion with the same json file exists. If it exists,
-        tries to merge the two tensor conversions.
+        Tries to merge the current conversion with the old one.
         """
-        if self.json.is_file():
-            try:
-                self._merge_conversion(check_transforms=check_transforms)
-            except ClinicaDLTensorConversionError as exc:
-                raise ClinicaDLTensorConversionError(
-                    f"{str(self.json)} already exists, so ClinicaDL tried to merge the current tensor conversion "
-                    "with the old one. But an error occurred, most likely because the two conversions concern "
-                    "different kinds of data (e.g. different preprocessing, different transforms applied, different "
-                    "masks used).\n"
-                    "See exception traceback for more details. If you want to run a new tensor conversion, "
-                    "please give an available 'conversion_name'."
-                ) from exc
+        try:
+            self._merge_conversion(check_transforms=check_transforms)
+        except ClinicaDLTensorConversionError as exc:
+            raise ClinicaDLTensorConversionError(
+                f"{str(self.json)} already exists, so ClinicaDL tried to merge the current tensor conversion "
+                "with the old one. But an error occurred, most likely because the two conversions concern "
+                "different kinds of data (e.g. different preprocessing, different transforms applied, different "
+                "masks used).\n"
+                "See exception traceback for more details. If you want to run a new tensor conversion, "
+                "please give an available 'conversion_name'."
+            ) from exc
 
     def _merge_conversion(
         self,

--- a/clinicadl/data/utils.py
+++ b/clinicadl/data/utils.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+from typing import Union
+
+from clinicadl.dictionary.suffixes import JSON
+from clinicadl.dictionary.words import DEFAULT
+
+from .readers import CapsReader
+from .tensor_conversion import TensorConversionInfo
+
+
+def remove_tensors(caps_directory: Union[str, Path], conversion_name: str) -> None:
+    """
+    To remove some tensors of a :term:`CAPS` directory.
+
+    Will remove all the tensors saved with :py:class:`clinicadl.data.datasets.CapsDataset.to_tensors`
+    and associated to ``conversion_name``, as well as the associated ``JSON`` file in ``{caps_directory}/tensor_conversion``.
+
+    Parameters
+    ----------
+    caps_directory : Union[str, Path]
+        The :term:`CAPS` directory where to remove the tensors.
+    conversion_name : str
+        The name of the ``JSON`` file ``{caps_directory}/tensor_conversion``, without the ``.json``
+        extension.
+
+    Examples
+    --------
+
+    .. code-block::
+
+        from clinicadl.data import datasets, datatypes
+        from clinicadl.data.utils import remove_tensors
+
+        caps_dataset = datasets.CapsDataset(
+            caps_directory="my_caps", preprocessing=datatypes.T1Linear(use_uncropped_image=True)
+        )
+        caps_dataset.to_tensors()  # the json file will be "default_t1-linear.json"
+
+        remove_tensors(caps_directory="my_caps", conversion_name="default_t1-linear")
+
+    .. code-block::
+
+        caps_dataset.to_tensors(conversion_name="a_conversion")
+
+        remove_tensors(caps_directory="my_caps", conversion_name="a_conversion")
+
+    See Also
+    --------
+    :py:class:`clinicadl.data.datasets.CapsDataset.to_tensors`
+    """
+    caps_reader = CapsReader(Path(caps_directory))
+
+    if conversion_name.startswith(DEFAULT):
+        tensor_folder_name = DEFAULT
+    else:
+        tensor_folder_name = conversion_name
+
+    json_name = Path(conversion_name).with_suffix(JSON)
+    json = caps_reader.tensor_conversion_json_dir / json_name
+
+    tensor_conversion = TensorConversionInfo.from_json(json)
+
+    for participant, session in tensor_conversion.participants_sessions:
+        pt_path = caps_reader.get_tensor_path(
+            participant,
+            session,
+            tensor_conversion.preprocessing,
+            conversion_name=tensor_folder_name,
+        )
+        pt_path.unlink()
+
+        is_empty = not any(pt_path.parent.iterdir())
+        if is_empty:
+            pt_path.parent.rmdir()
+
+    json.unlink()

--- a/clinicadl/metrics/config/classification.py
+++ b/clinicadl/metrics/config/classification.py
@@ -15,6 +15,7 @@ from .enum import Average, ConfusionMatrixMetricName, Optimum
 __all__ = [
     "ROCAUCMetricConfig",
     "ConfusionMatrixMetricConfig",
+    "AveragePrecisionMetricConfig",
 ]
 
 ROC_AUC_METRIC_METRICS_DEFAULTS = get_defaults_from(monai.metrics.rocauc.ROCAUCMetric)

--- a/docs/api/data/index.rst
+++ b/docs/api/data/index.rst
@@ -72,3 +72,17 @@
    datasets
    datatypes
    structures
+
+:mod:`clinicadl.data.utils`
+---------------------------
+
+.. automodule:: clinicadl.data.utils
+
+.. currentmodule:: clinicadl.data.utils
+
+.. autosummary::
+    :toctree: ../generated/
+    :nosignatures:
+    :template: autosummary/function.rst
+
+    remove_tensors

--- a/tests/unittests/data/test_tensor_conversion.py
+++ b/tests/unittests/data/test_tensor_conversion.py
@@ -74,9 +74,6 @@ def copy_caps():
     if tmp_dir.is_dir():
         shutil.rmtree(tmp_dir)
     shutil.copytree(caps_dir, tmp_dir)
-    Path(tmp_dir / "tensor_conversion" / "pet_ref_corrupted.json").unlink()
-    Path(tmp_dir / "tensor_conversion" / "pet_ref_corrupted_bis.json").unlink()
-    Path(tmp_dir / "tensor_conversion" / "pet_ref_missing_field.json").unlink()
 
 
 def copy_caps_without_tensors():
@@ -824,6 +821,64 @@ def test_convert_to_tensors():
         match="If 'save_transforms' is True, 'conversion_name' cannot be None.",
     ):
         converter.convert_to_tensors(save_transforms=True)
+
+    shutil.rmtree(tmp_dir)
+
+
+def test_overwrite():
+    copy_caps()
+    data = sub_data(
+        [
+            ("sub-000", "ses-M000"),
+        ]
+    )
+    preprocessing = T1Linear(use_uncropped_image=True)
+    caps_dataset = CapsDataset(
+        tmp_dir, preprocessing=preprocessing, data=data, masks=["brain"]
+    )
+    converter = TensorConversion(caps_dataset)
+
+    with pytest.raises(
+        ClinicaDLTensorConversionError,
+        match=r".*already exists, so ClinicaDL tried to merge*",
+    ):
+        converter.convert_to_tensors()
+
+    converter.convert_to_tensors(overwrite=True)
+
+    with open(tmp_dir / "tensor_conversion" / "default_t1-linear.json", "r") as f:
+        conversion_info = json.load(f)
+    assert conversion_info["individual_masks"] == ["brain"]
+    tensors = torch.load(
+        tmp_dir
+        / "subjects"
+        / "sub-000"
+        / "ses-M000"
+        / "t1_linear"
+        / "tensors"
+        / "default"
+        / "sub-000_ses-M000_space-MNI152NLin2009cSym_res-1x1x1_T1w.pt",
+        weights_only=True,
+    )
+    assert "brain" in tensors
+
+    converter.convert_to_tensors(conversion_name="t1_masks", overwrite=True)
+
+    with open(tmp_dir / "tensor_conversion" / "t1_masks.json", "r") as f:
+        conversion_info = json.load(f)
+    assert conversion_info["individual_masks"] == ["brain"]
+    tensors = torch.load(
+        tmp_dir
+        / "subjects"
+        / "sub-000"
+        / "ses-M000"
+        / "t1_linear"
+        / "tensors"
+        / "t1_masks"
+        / "sub-000_ses-M000_space-MNI152NLin2009cSym_res-1x1x1_T1w.pt",
+        weights_only=True,
+    )
+    assert "seg" not in tensors
 
     shutil.rmtree(tmp_dir)
 

--- a/tests/unittests/data/test_utils.py
+++ b/tests/unittests/data/test_utils.py
@@ -1,0 +1,48 @@
+import shutil
+from pathlib import Path
+
+import pytest
+import torch
+
+from clinicadl.data.utils import remove_tensors
+
+caps_dir = Path(__file__).parents[1] / "resources" / "caps_example"
+tmp_dir = Path(__file__).parents[1] / "resources" / "caps_tmp"
+
+
+def copy_caps():
+    if tmp_dir.is_dir():
+        shutil.rmtree(tmp_dir)
+    shutil.copytree(caps_dir, tmp_dir)
+
+
+@pytest.mark.parametrize(
+    "conversion_name,tensor_dir",
+    [("default_t1-linear", "default"), ("t1_masks", "t1_masks")],
+)
+def test_remove_tensors(conversion_name, tensor_dir):
+    copy_caps()
+    sub_ses_dir = (
+        tmp_dir / "subjects" / "sub-000" / "ses-M000" / "t1_linear" / "tensors"
+    )
+    sub_ses_dir_bis = (
+        tmp_dir / "subjects" / "sub-010" / "ses-M003" / "t1_linear" / "tensors"
+    )
+    torch.save(dict(), sub_ses_dir_bis / tensor_dir / "abc.pt")
+
+    remove_tensors(str(tmp_dir), conversion_name)
+
+    assert (
+        not (tmp_dir / "tensor_conversion" / conversion_name)
+        .with_suffix(".json")
+        .exists()
+    )
+    assert not (sub_ses_dir / tensor_dir).exists()
+    assert not (
+        sub_ses_dir_bis
+        / tensor_dir
+        / "sub-010_ses-M003_space-MNI152NLin2009cSym_res-1x1x1_T1w.pt"
+    ).exists()
+    assert (sub_ses_dir_bis / tensor_dir / "abc.pt").exists()
+
+    shutil.rmtree(tmp_dir)


### PR DESCRIPTION
Some users express the need to have the possibility to overwrite an old tensor conversion.
This PR aims to add this feature, i.e. an argument named "overwrite" in ``CapsDataset.to_tensors``.

To enable the user to remove tensors without having to instantiate a ``CapsDataset``, I also created a function named ``remove_tensors`` in ``clinicadl.data.utils``.