### PR TITLE
New batch object

### DIFF
--- a/clinicadl/data/dataloader/__init__.py
+++ b/clinicadl/data/dataloader/__init__.py
@@ -1,5 +1,5 @@
 """To build a :py:class:`PyTorch DataLoader <torch.utils.data.DataLoader>`
 adapted to ``ClinicaDL``."""
 
-from .batch import Batch
+from .batch import Batch, BatchType
 from .config import DataLoaderConfig

--- a/clinicadl/data/dataloader/batch.py
+++ b/clinicadl/data/dataloader/batch.py
@@ -15,45 +15,51 @@ class Batch(list[DataPoint]):
     """
     A batch container for :class:`~clinicadl.data.structures.DataPoint` objects.
 
-    This class inherits from the built-in :class:`list` and is specifically designed
-    to handle batches of ``DataPoint`` instances.
+    ``Batch`` is simply a list of ``DataPoints``, with additional useful functions.
 
     Parameters
     ----------
-    samples : list[DataPoint]
-        List of :py:class:`~clinicadl.data.structures.DataPoint` forming the batch.
+    datapoints : list[DataPoint]
+        List of :py:class:`DataPoints <clinicadl.data.structures.DataPoint>` forming the batch.
 
     Raises
     ------
     ValueError
-        If the input list of samples is empty.
+        If the input list is empty.
 
     """
 
     _device: Optional[torch.device] = None
     _non_blocking: bool = False
 
-    def __init__(self, samples: list[DataPoint]):
-        super().__init__(samples)
+    def __init__(self, datapoints: list[DataPoint]):
+        super().__init__(datapoints)
 
         if len(self) == 0:
             raise ValueError("The batch is empty!")
 
     @property
     def device(self) -> torch.device:
-        """The device on which are the tensors in the batch."""
+        """The device on which the :py:class:`Tensors <torch.Tensor>` in the batch are."""
         return self._device
 
     def to(
         self, device: Union[str, int, torch.device], non_blocking: bool = False
     ) -> Batch:
         """
-        Returns a copy of the ``Batch`` on the specified device.
+        Returns a copy of the ``Batch``, where :py:class:`Tensors <torch.Tensor>` are on the specified device.
 
         Parameters
         ----------
         device : Union[str, int, torch.device]
-            The device where to send the ``Batch``.
+            The device where to send the ``Batch``. Can be:
+
+            - an ``int``: the device id;
+            - ``"cuda"``;
+            - ``"cpu"``
+            - ``"cuda-<id>"``: where ``<id>`` is the device id;
+            - a :py:class:`torch.device`.
+
         non_blocking : bool, default=False
             "When non_blocking is set to ``True``, the function attempts to perform the
             conversion asynchronously with respect to the host, if possible.
@@ -63,10 +69,10 @@ class Batch(list[DataPoint]):
         Returns
         -------
         Batch
-            The copy of the input batch, on the wanted device.
+            The copy of the input batch, on the specified device.
         """
         if isinstance(device, str) and not (
-            re.match(r"^cuda:.*", device) or device == "cuda"
+            re.match(r"^cuda:.*", device) or device == "cuda" or device == "cpu"
         ):
             raise ValueError(
                 "If 'device' is a str, it must be 'cuda' or 'cuda:<device-id>'."
@@ -93,15 +99,13 @@ class Batch(list[DataPoint]):
         ensure_channel_dim: bool = False,
     ) -> Union[torch.Tensor, list[Any]]:
         """
-        Gathers all the values of a field in the :py:class:`~clinicadl.data.structures.DataPoint` in the batch.
+        Gathers all the values of a field that is in the ``DataPoints`` of the batch.
 
-        The function will try to return the output as a batch-first :py:class`torch.Tensor`. If not possible,
+        The function will try to return the output as a batch-first :py:class:`torch.Tensor`. If not possible,
         it will return the list of the values.
 
-        The tensor will be returned on the device passed via :py:meth:`to`.
-
-        Besides, if the output is a ``Tensor``, the desired data type and the memory format can be specified via
-        ``dtype`` and ``channels_last`` respectively.
+        If the output is a ``Tensor``, it will be returned on the device passed via :py:meth:`to`, and the desired data type
+        as well as the memory format can be specified via ``dtype`` and ``channels_last`` respectively.
 
         Parameters
         ----------
@@ -112,9 +116,9 @@ class Batch(list[DataPoint]):
             be cast into a specific data type.
         channels_last : Optional[bool], default=None
             Whether to use `Channels Last Memory Format <https://docs.pytorch.org/tutorials/intermediate/memory_format_tutorial.html>`_
-            for the output tensor.
+            for the output ``Tensor``. If ``None``, memory format will not be changed.
         ensure_channel_dim : bool, default=False
-            If ``True``, a 1D tensor output batche (B) will be unsqueezed to 2D tensor with a channel dimension (BC).
+            If ``True``, a 1D ``Tensor`` output batch (B) will be unsqueezed to a 2D ``Tensor`` with a channel dimension (BC).
 
         Returns
         -------
@@ -124,9 +128,35 @@ class Batch(list[DataPoint]):
         Raises
         ------
         KeyError
-            If not all the :py:class:`~clinicadl.data.structures.DataPoint` have the requested ``field_name``.
+            If not all the :py:class:`DataPoints <clinicadl.data.structures.DataPoint>` have the requested ``field_name``.
         ValueError
             If ``channels_last=True`` but the batch tensor is not 4D (BCHW) or 5D (BCDHW).
+
+        Examples
+        --------
+        .. code-block:: python
+
+            from clinicadl.data.structures import ColinDataPoint
+            from clinicadl.data.dataloader import Batch
+            datapoint = ColinDataPoint()
+            batch = Batch([datapoint, datapoint])
+
+        .. code-block:: python
+
+            >>> datapoint
+            ColinDataPoint(Keys: ('image', 'label', 'participant', 'session', 'head'); images: 3)
+            >>> datapoint["label"]
+            LabelMap(shape: (1, 181, 217, 181); spacing: (1.00, 1.00, 1.00); orientation: RAS+; dtype: torch.ShortTensor; memory: 13.6 MiB)
+            >>> datapoint["participant"]
+            'sub-colin'
+
+        .. code-block:: python
+
+            >>> batch.get_field("label").shape
+            torch.Size([2, 1, 181, 217, 181])
+            >>> batch.get_field("participant")
+            ['sub-colin', 'sub-colin']
+
         """
         # collect all the values and try to convert them to tensors
         batch = []

--- a/clinicadl/data/dataloader/batch.py
+++ b/clinicadl/data/dataloader/batch.py
@@ -1,23 +1,27 @@
-from typing import Any, List, Union
+from __future__ import annotations
 
+import re
+from copy import deepcopy
+from typing import Any, Optional, Union
+
+import numpy as np
 import torch
 import torchio as tio
 
 from clinicadl.data.structures import DataPoint
 
 
-class SimpleBatch(list[DataPoint]):
+class Batch(list[DataPoint]):
     """
     A batch container for :class:`~clinicadl.data.structures.DataPoint` objects.
 
     This class inherits from the built-in :class:`list` and is specifically designed
-    to handle batches of `DataPoint` instances, providing utility methods to
-    retrieve their associated image tensors and labels.
+    to handle batches of ``DataPoint`` instances.
 
     Parameters
     ----------
     samples : list[DataPoint]
-        List of :class:`~clinicadl.data.structures.DataPoint` forming the batch.
+        List of :py:class:`~clinicadl.data.structures.DataPoint` forming the batch.
 
     Raises
     ------
@@ -26,78 +30,199 @@ class SimpleBatch(list[DataPoint]):
 
     """
 
+    _device: Optional[torch.device] = None
+    _non_blocking: bool = False
+
     def __init__(self, samples: list[DataPoint]):
         super().__init__(samples)
 
         if len(self) == 0:
-            raise ValueError("The batch is empty")
+            raise ValueError("The batch is empty!")
 
-    def get_images(self) -> Union[torch.Tensor, list[torch.Tensor]]:
+    @property
+    def device(self) -> torch.device:
+        """The device on which are the tensors in the batch."""
+        return self._device
+
+    def to(
+        self, device: Union[str, int, torch.device], non_blocking: bool = False
+    ) -> Batch:
         """
-        Gathers the images in the batch as :py:class:`torch.Tensor`.
+        Returns a copy of the ``Batch`` on the specified device.
+
+        Parameters
+        ----------
+        device : Union[str, int, torch.device]
+            The device where to send the ``Batch``.
+        non_blocking : bool, default=False
+            "When non_blocking is set to ``True``, the function attempts to perform the
+            conversion asynchronously with respect to the host, if possible.
+            This asynchronous behavior applies to both pinned and pageable memory."
+            (see :torch:`PyTorch documentation <generated/torch.Tensor.to.html>`).
 
         Returns
         -------
-        Union[torch.Tensor, list[torch.Tensor]]
-            A tensor containing all the images from the batch if they
-            have the same size. A list of tensors otherwise.
-
-            If a tensor is returned, the first dimension is the batch
-            dimension.
+        Batch
+            The copy of the input batch, on the wanted device.
         """
-        images = [sample.image.tensor for sample in self]
+        if isinstance(device, str) and not re.match(r"^cuda:.*", device):
+            raise ValueError(
+                "If 'device' is a str, it must be like 'cuda:<device-id>'."
+            )
+
+        batch = deepcopy(self)
+
+        for datapoint in batch:
+            for name, value in datapoint.items():
+                if isinstance(value, torch.Tensor):
+                    datapoint[name] = value.to(device, non_blocking=non_blocking)
+            datapoint.update_attributes()
+
+        batch._device = torch.device(device)
+        batch._non_blocking = non_blocking
+
+        return batch
+
+    def get_field(
+        self,
+        field_name: str,
+        dtype: Optional[torch.dtype] = None,
+        channels_last: Optional[bool] = None,
+        ensure_channel_dim: bool = False,
+    ) -> Union[torch.Tensor, list[Any]]:
+        """
+        Gathers all the values of a field in the :py:class:`~clinicadl.data.structures.DataPoint` in the batch.
+
+        The function will try to return the output as a batch-first :py:class`torch.Tensor`. If not possible,
+        it will return the list of the values.
+
+        The tensor will be returned on the device passed via :py:meth:`to`.
+
+        Besides, if the output is a ``Tensor``, the desired data type and the memory format can be specified via
+        ``dtype`` and ``channels_last`` respectively.
+
+        Parameters
+        ----------
+        field_name : str
+            The key to the field in the underlying :py:class:`DataPoints <clinicadl.data.structures.DataPoint>`.
+        dtype : Optional[torch.dtype], default=None
+            Specifies the output data type, if the output is a ``Tensor``. If ``None``, the output will not
+            be cast into a specific data type.
+        channels_last : Optional[bool], default=None
+            Whether to use `Channels Last Memory Format <https://docs.pytorch.org/tutorials/intermediate/memory_format_tutorial.html>`_
+            for the output tensor.
+        ensure_channel_dim : bool, default=False
+            If ``True``, a 1D tensor output batche (B) will be unsqueezed to 2D tensor with a channel dimension (BC).
+
+        Returns
+        -------
+        Union[torch.Tensor, list[Any]]
+            A :py:class:`torch.Tensor` or a list containing all the values of ``field_name`` in the batch.
+
+        Raises
+        ------
+        KeyError
+            If not all the :py:class:`~clinicadl.data.structures.DataPoint` have the requested ``field_name``.
+        ValueError
+            If ``channels_last=True`` but the batch tensor is not 4D (BCHW) or 5D (BCDHW).
+        """
+        # collect all the values and try to convert them to tensors
+        batch = []
         try:
-            return torch.stack(images, dim=0)
-        except RuntimeError:  # not the same shape
-            return images
+            for datapoint in self:
+                value = self._get_field(datapoint, field_name)
 
-    def get_labels(self) -> Union[torch.Tensor, List[Any]]:
-        """
-        Gathers the labels in the batch.
+                try:
+                    value = self._to_tensor(value)
+                except TypeError:
+                    raise StopIteration
 
-        Returns
-        -------
-        Union[torch.Tensor, List[Any]]
-            A :py:class:`torch.Tensor` or a list containing all the labels from the batch.
-            It will be a list if the labels are heterogeneous (e.g. a mask and a scalar) or if any
-            of the label is ``None``. Otherwise, it will be a tensor.
-        """
-        labels = [
-            sample.label.tensor
-            if isinstance(sample.label, tio.LabelMap)
-            else self._dict_to_tensor(sample.label)
-            if isinstance(sample.label, dict)
-            else sample.label
-            for sample in self
-        ]
+                batch.append(value)
 
-        if all(isinstance(label, torch.Tensor) for label in labels):
+        except StopIteration:  # some field values cannot be converted to tensors
+            return [self._get_field(datapoint, field_name) for datapoint in self]
+        else:  # now let's merge in one tensor
             try:
-                return torch.stack(labels, dim=0)
-            except RuntimeError:  # not the same shape
-                return labels
+                batch = torch.stack(batch, dim=0)
+            except RuntimeError:  # not the same shape, batch as tensor is not possible
+                return [self._get_field(datapoint, field_name) for datapoint in self]
 
-        try:
-            return torch.tensor(labels)
-        except (TypeError, ValueError, RuntimeError):  # e.g. None in labels
-            return labels
+        # format the batch tensor
+        if len(batch.shape) == 1 and ensure_channel_dim:  # at least two dimensions
+            batch = batch.unsqueeze(1)
+
+        memory_format = self._get_memory_format(batch, channels_last=channels_last)
+
+        return batch.to(
+            dtype=dtype,
+            device=self._device,
+            non_blocking=self._non_blocking,
+            memory_format=memory_format,
+        )
 
     @staticmethod
-    def _dict_to_tensor(dict_: dict[str, float]) -> torch.Tensor:
+    def _get_field(datapoint: DataPoint, field_name: str) -> Any:
+        """Returns the specified field."""
+        try:
+            return datapoint[field_name]
+        except KeyError as e:
+            raise KeyError(
+                f"You want to get '{field_name}', but there is no such key in some DataPoints in the batch."
+            ) from e
+
+    @classmethod
+    def _to_tensor(cls, value: Any) -> torch.Tensor:
         """
-        To convert multi-scalars label.
+        Tries to convert to a tensor.
         """
-        return torch.tensor([value for _, value in dict_.items()], dtype=torch.float32)
+        if isinstance(value, tio.ScalarImage):
+            return value.tensor.float()
+        elif isinstance(value, tio.LabelMap):
+            return value.tensor.int()
+        elif isinstance(value, np.ndarray):
+            return torch.from_numpy(value)
+        elif isinstance(value, dict):
+            return cls._to_tensor(list(value.values()))
+        elif isinstance(value, torch.Tensor):
+            return value
+        else:
+            try:
+                return torch.tensor(value)
+            except (TypeError, ValueError, RuntimeError) as exc:
+                raise TypeError from exc
+
+    @staticmethod
+    def _get_memory_format(
+        tensor: torch.Tensor,
+        channels_last: Optional[bool],
+    ) -> torch.memory_format:
+        """
+        Gets the desired memory format.
+        """
+        if channels_last:
+            if len(tensor.shape) == 4:
+                return torch.channels_last
+            elif len(tensor.shape) == 5:
+                return torch.channels_last_3d
+            else:
+                raise ValueError(
+                    "To use Channels Last memory format, the output tensor must be 4D (BCHW) or 5D (BCDHW). "
+                    f"Here it is {int(len(tensor.shape))}D."
+                )
+        elif channels_last is False:
+            return torch.contiguous_format
+        else:
+            return torch.preserve_format
 
 
-Batch = Union[SimpleBatch, tuple[SimpleBatch, ...]]
+BatchType = Union[Batch, tuple[Batch, ...]]
 
 
-def simple_collate_fn(batch: list[DataPoint]) -> SimpleBatch:
+def simple_collate_fn(batch: list[DataPoint]) -> Batch:
     """For datasets that returns a single Sample."""
-    return SimpleBatch(batch)
+    return Batch(batch)
 
 
-def tuple_collate_fn(batch: list[tuple[DataPoint, ...]]) -> tuple[SimpleBatch, ...]:
+def tuple_collate_fn(batch: list[tuple[DataPoint, ...]]) -> tuple[Batch, ...]:
     """For datasets that returns a tuple of Samples."""
-    return tuple(SimpleBatch(data) for data in zip(*batch))
+    return tuple(Batch(data) for data in zip(*batch))

--- a/clinicadl/data/dataloader/batch.py
+++ b/clinicadl/data/dataloader/batch.py
@@ -65,9 +65,11 @@ class Batch(list[DataPoint]):
         Batch
             The copy of the input batch, on the wanted device.
         """
-        if isinstance(device, str) and not re.match(r"^cuda:.*", device):
+        if isinstance(device, str) and not (
+            re.match(r"^cuda:.*", device) or device == "cuda"
+        ):
             raise ValueError(
-                "If 'device' is a str, it must be like 'cuda:<device-id>'."
+                "If 'device' is a str, it must be 'cuda' or 'cuda:<device-id>'."
             )
 
         batch = deepcopy(self)

--- a/clinicadl/data/dataloader/config.py
+++ b/clinicadl/data/dataloader/config.py
@@ -11,10 +11,10 @@ from clinicadl.data.datasets import (
 )
 from clinicadl.data.datasets.types import Dataset, SimpleDataset, TupleDataset
 from clinicadl.utils.config import ClinicaDLConfig
-from clinicadl.utils.json import read_json, update_json, write_json
+from clinicadl.utils.json import update_json, write_json
 from clinicadl.utils.seed import pl_worker_init_function
 
-from .batch import SimpleBatch, simple_collate_fn, tuple_collate_fn
+from .batch import Batch, simple_collate_fn, tuple_collate_fn
 
 
 class DataLoader(TorchDataLoader):
@@ -45,7 +45,7 @@ class _SimpleDataLoader(DataLoader):
 
     def __iter__(
         self,
-    ) -> Iterator[SimpleBatch]:
+    ) -> Iterator[Batch]:
         return super().__iter__()
 
 
@@ -54,7 +54,7 @@ class _TupleDataLoader(DataLoader):
 
     def __iter__(
         self,
-    ) -> Iterator[tuple[SimpleBatch, ...]]:
+    ) -> Iterator[tuple[Batch, ...]]:
         return super().__iter__()
 
 

--- a/clinicadl/model/clinicadl_model.py
+++ b/clinicadl/model/clinicadl_model.py
@@ -8,7 +8,7 @@ import torch.nn as nn
 from torch.amp.grad_scaler import GradScaler
 from torch.optim.optimizer import Optimizer
 
-from clinicadl.data.dataloader import Batch
+from clinicadl.data.dataloader import BatchType
 from clinicadl.losses.config import LossConfig, get_loss_function_config
 from clinicadl.losses.types import Loss
 from clinicadl.metrics.handler import MetricsHandler
@@ -122,7 +122,7 @@ class ClinicaDLModel:
 
         return model_state["epoch"]
 
-    def training_step(self, data: Batch, device: torch.device) -> torch.Tensor:
+    def training_step(self, data: BatchType, device: torch.device) -> torch.Tensor:
         """
         Perform a training step on the model using the provided batch of data and return the computed loss
         """

--- a/clinicadl/model/clinicadl_model.py
+++ b/clinicadl/model/clinicadl_model.py
@@ -139,7 +139,7 @@ class ClinicaDLModel:
         return loss
 
     def validation_step(
-        self, data: Batch, device: torch.device, metrics: MetricsHandler
+        self, data: BatchType, device: torch.device, metrics: MetricsHandler
     ) -> MetricsHandler:
         """
         Perform a training step on the model using the provided batch of data and return the computed loss

--- a/docs/api/data/dataloader.rst
+++ b/docs/api/data/dataloader.rst
@@ -14,4 +14,4 @@
     :template: autosummary/class.rst
 
     DataLoaderConfig
-    batch.SimpleBatch
+    Batch

--- a/docs/api/data/index.rst
+++ b/docs/api/data/index.rst
@@ -17,7 +17,7 @@
     :template: autosummary/class.rst
 
     DataLoaderConfig
-    batch.SimpleBatch
+    Batch
 
 
 :mod:`clinicadl.data.datasets`

--- a/tests/unittests/data/dataloader/test_batch.py
+++ b/tests/unittests/data/dataloader/test_batch.py
@@ -143,10 +143,13 @@ def test_to():
     batch.to(torch.device("cuda:0"), non_blocking=True)
 
     batch_gpu = batch.to(0, non_blocking=True)
+    batch_cpu = batch.to("cpu")
     assert batch_gpu._non_blocking
     assert batch_gpu.device == torch.device("cuda:0")
     assert not batch._non_blocking
     assert batch.device is None
+    assert not batch_cpu._non_blocking
+    assert batch_cpu.device == torch.device("cpu")
 
     assert batch[0]["label"].device == torch.device("cpu")
     assert batch_gpu[0]["label"].device == torch.device("cuda:0")

--- a/tests/unittests/data/dataloader/test_batch.py
+++ b/tests/unittests/data/dataloader/test_batch.py
@@ -127,6 +127,7 @@ def test_to():
                 image=tio.ScalarImage(tensor=torch.randn(1, 3, 4, 5)),
                 label=torch.randn(2),
                 output=1,
+                abc=torch.randn(2, device=torch.device("cuda:0")),
                 participant=f"sub-{i}",
                 session=f"ses-{i}",
             )
@@ -136,10 +137,15 @@ def test_to():
     batch_gpu = batch.to(0, non_blocking=True)
     assert batch_gpu._non_blocking
     assert batch_gpu.device == torch.device("cuda:0")
-    assert batch.device == torch.device("cpu")
+    assert not batch._non_blocking
+    assert batch.device is None
 
     assert batch[0]["label"].device == torch.device("cpu")
     assert batch_gpu[0]["label"].device == torch.device("cuda:0")
+
+    assert batch[0]["abc"].device == torch.device("cuda:0")
+    assert batch_gpu[0]["abc"].device == torch.device("cuda:0")
+
     assert batch.get_field("output").device == torch.device("cpu")
     assert batch_gpu.get_field("output").device == torch.device("cuda:0")
 

--- a/tests/unittests/data/dataloader/test_batch.py
+++ b/tests/unittests/data/dataloader/test_batch.py
@@ -46,7 +46,7 @@ def test_get_field():
     assert labels[-1].size() == (1, 3, 4, 6)
 
     # numpy and list
-    batch[0]["label"] = list(np.ones((1, 3, 4, 5)))
+    batch[0]["label"] = np.ones((1, 3, 4, 5)).tolist()
     batch[-1]["label"] = np.ones((1, 3, 4, 5))
     labels = batch.get_field("label")
     assert labels.size() == (2, 1, 3, 4, 5)

--- a/tests/unittests/data/dataloader/test_batch.py
+++ b/tests/unittests/data/dataloader/test_batch.py
@@ -134,6 +134,13 @@ def test_to():
             for i in range(2)
         ]
     )
+    with pytest.raises(
+        ValueError, match="If 'device' is a str, it must be like 'cuda:<device-id>'."
+    ):
+        batch.to("cuda-0", non_blocking=True)
+    batch.to("cuda", non_blocking=True)
+    batch.to(torch.device("cuda:0"), non_blocking=True)
+
     batch_gpu = batch.to(0, non_blocking=True)
     assert batch_gpu._non_blocking
     assert batch_gpu.device == torch.device("cuda:0")

--- a/tests/unittests/data/dataloader/test_batch.py
+++ b/tests/unittests/data/dataloader/test_batch.py
@@ -1,12 +1,19 @@
+import numpy as np
+import pytest
 import torch
 import torchio as tio
 
-from clinicadl.data.dataloader.batch import SimpleBatch
+from clinicadl.data.dataloader.batch import Batch, simple_collate_fn, tuple_collate_fn
 from clinicadl.data.structures import DataPoint
 
 
-def test_SimpleBatch():
-    # tensor labels
+def test_init():
+    with pytest.raises(ValueError, match="The batch is empty!"):
+        Batch([])
+
+
+def test_get_field():
+    # torchio images
     list_samples = [
         DataPoint(
             image=tio.ScalarImage(tensor=torch.randn(1, 3, 4, 5)),
@@ -16,124 +23,152 @@ def test_SimpleBatch():
         )
         for i in range(2)
     ]
-    batch = SimpleBatch(list_samples)
-    images = batch.get_images()
+    batch = Batch(list_samples)
+    images = batch.get_field("image")
     assert images.size() == (2, 1, 3, 4, 5)
-    labels = batch.get_labels()
+    labels = batch.get_field("label")
     assert labels.size() == (2, 1, 3, 4, 5)
 
-    # different shapes
-    batch.append(
-        DataPoint(
-            image=tio.ScalarImage(tensor=torch.randn(1, 3, 4, 6)),
-            label=tio.LabelMap(tensor=torch.ones(1, 3, 4, 6)),
-            participant="sub-2",
-            session="ses-2",
-        )
-    )
-    labels = batch.get_labels()
-    images = batch.get_images()
-    assert isinstance(images, list)
-    assert images[0].size() == (1, 3, 4, 5)
-    assert images[-1].size() == (1, 3, 4, 6)
-    assert isinstance(labels, list)
-    assert labels[0].size() == (1, 3, 4, 5)
-    assert labels[-1].size() == (1, 3, 4, 6)
-
-    # heterogeneous labels
+    # tensors and different shapes
     batch[-1] = DataPoint(
         image=tio.ScalarImage(tensor=torch.randn(1, 3, 4, 6)),
-        label=1,
-        participant="sub-2",
-        session="ses-2",
+        label=torch.ones(1, 3, 4, 6),
+        participant="sub-1",
+        session="ses-1",
     )
-    labels = batch.get_labels()
+    labels = batch.get_field("label")
+    images = batch.get_field("image")
+    assert isinstance(images, list)
+    assert isinstance(images[0], tio.ScalarImage)
+    assert isinstance(images[-1], tio.ScalarImage)
     assert isinstance(labels, list)
-    assert labels[0].size() == (1, 3, 4, 5)
-    assert labels[-1] == 1
+    assert isinstance(labels[0], tio.LabelMap)
+    assert labels[-1].size() == (1, 3, 4, 6)
 
-    # a None label
-    batch[-1] = DataPoint(
-        image=tio.ScalarImage(tensor=torch.ones(1, 3, 4, 6)),
-        label=None,
-        participant="sub-2",
-        session="ses-2",
-    )
-    labels = batch.get_labels()
+    # numpy and list
+    batch[0]["label"] = list(np.ones((1, 3, 4, 5)))
+    batch[-1]["label"] = np.ones((1, 3, 4, 5))
+    labels = batch.get_field("label")
+    assert labels.size() == (2, 1, 3, 4, 5)
+
+    # None
+    batch[-1]["label"] = None
+    labels = batch.get_field("label")
     assert isinstance(labels, list)
-    assert labels[0].size() == (1, 3, 4, 5)
+    assert isinstance(labels[0], list)
     assert labels[-1] is None
 
-    # a dict label
-    batch[-1] = DataPoint(
-        image=tio.ScalarImage(tensor=torch.ones(1, 3, 4, 6)),
-        label={"A": 0, "B": 1},
-        participant="sub-2",
-        session="ses-2",
-    )
-    labels = batch.get_labels()
-    assert isinstance(labels, list)
+    # dict
+    batch[0]["label"] = {"A": 0.0, "B": 1.0}
+    batch[-1]["label"] = {"A": 2.0, "B": 3.0}
+    labels = batch.get_field("label")
     torch.testing.assert_close(
-        labels[-1], torch.tensor([0.0, 1.0], dtype=torch.float32)
+        labels, torch.tensor([[0.0, 1.0], [2.0, 3.0]], dtype=torch.float32)
     )
 
-    # all int labels
-    list_samples = [
-        DataPoint(
-            image=tio.ScalarImage(tensor=torch.randn(1, 3, 4, 5)),
-            label=i,
-            participant=f"sub-{i}",
-            session=f"ses-{i}",
-        )
-        for i in range(2)
-    ]
-    batch = SimpleBatch(list_samples)
-    labels = batch.get_labels()
+    batch[0]["label"] = {"A": 0, "B": "abc"}
+    labels = batch.get_field("label")
+    assert isinstance(labels, list)
+    assert isinstance(labels[0], dict)
+
+    # homogeneous numerics
+    batch[0]["label"] = 0
+    batch[-1]["label"] = 1
+    labels = batch.get_field("label")
     torch.testing.assert_close(labels, torch.tensor([0, 1], dtype=torch.int64))
 
-    # all float in labels
-    list_samples = [
-        DataPoint(
-            image=tio.ScalarImage(tensor=torch.randn(1, 3, 4, 5)),
-            label=float(i),
-            participant=f"sub-{i}",
-            session=f"ses-{i}",
-        )
-        for i in range(2)
-    ]
-    batch = SimpleBatch(list_samples)
-    labels = batch.get_labels()
+    batch[0]["label"] = 0.0
+    batch[-1]["label"] = 1.0
+    labels = batch.get_field("label")
     torch.testing.assert_close(labels, torch.tensor([0.0, 1.0], dtype=torch.float32))
 
-    # all dict in labels
+    # dtype
+    labels = batch.get_field("label", dtype=torch.int64)
+    torch.testing.assert_close(labels, torch.tensor([0.0, 1.0], dtype=torch.int64))
+
+    # channels
+    batch[0]["label"] = torch.ones(1, 3, 4, 5)
+    batch[1]["label"] = torch.ones(1, 3, 4, 5)
+    labels = batch.get_field("label", channels_last=True)
+    assert labels.stride() == (60, 1, 20, 5, 1)
+    labels = batch.get_field("label", channels_last=False)
+    assert labels.stride() == (60, 60, 20, 5, 1)
+
+    batch[0]["label"] = torch.ones(1, 3, 4)
+    batch[1]["label"] = torch.ones(1, 3, 4)
+    labels = batch.get_field("label", channels_last=True)
+    assert labels.stride() == (12, 1, 4, 1)
+    labels = batch.get_field("label", channels_last=False)
+    assert labels.stride() == (12, 12, 4, 1)
+
+    batch[0]["label"] = 0
+    batch[1]["label"] = 1
+    labels = batch.get_field("label", ensure_channel_dim=True)
+    torch.testing.assert_close(labels, torch.tensor([[0], [1]]))
+
+    # errors
+    with pytest.raises(
+        ValueError,
+        match=r"To use Channels Last memory format, the output tensor must be 4D \(BCHW\) or 5D \(BCDHW\). Here it is 1D.",
+    ):
+        batch.get_field("label", channels_last=True)
+    with pytest.raises(
+        KeyError,
+        match="You want to get 'abc', but there is no such key in some DataPoints in the batch.",
+    ):
+        batch.get_field("abc")
+
+
+@pytest.mark.gpu
+def test_to():
+    batch = Batch(
+        [
+            DataPoint(
+                image=tio.ScalarImage(tensor=torch.randn(1, 3, 4, 5)),
+                label=torch.randn(2),
+                output=1,
+                participant=f"sub-{i}",
+                session=f"ses-{i}",
+            )
+            for i in range(2)
+        ]
+    )
+    batch_gpu = batch.to(0, non_blocking=True)
+    assert batch_gpu._non_blocking
+    assert batch_gpu.device == torch.device("cuda:0")
+    assert batch.device == torch.device("cpu")
+
+    assert batch["label"].device == torch.device("cpu")
+    assert batch_gpu["label"].device == torch.device("cuda:0")
+    assert batch.get_field("output").device == torch.device("cpu")
+    assert batch_gpu.get_field("output").device == torch.device("cuda:0")
+
+
+def test_simple_collate_fn():
     list_samples = [
         DataPoint(
             image=tio.ScalarImage(tensor=torch.randn(1, 3, 4, 5)),
-            label={"A": 0, "B": 1},
+            label=tio.LabelMap(tensor=torch.ones(1, 3, 4, 5)),
             participant=f"sub-{i}",
             session=f"ses-{i}",
         )
         for i in range(2)
     ]
-    batch = SimpleBatch(list_samples)
-    labels = batch.get_labels()
-    torch.testing.assert_close(
-        labels, torch.tensor([[0.0, 1.0], [0.0, 1.0]], dtype=torch.float32)
-    )
+    out = simple_collate_fn(list_samples)
+    assert isinstance(out, Batch)
 
-    # without tensors
+
+def test_tuple_collate_fn():
     list_samples = [
         DataPoint(
             image=tio.ScalarImage(tensor=torch.randn(1, 3, 4, 5)),
-            label={"A": 0, "B": 1} if i == 0 else 1 if i == 1 else None,
+            label=tio.LabelMap(tensor=torch.ones(1, 3, 4, 5)),
             participant=f"sub-{i}",
             session=f"ses-{i}",
         )
-        for i in range(3)
+        for i in range(2)
     ]
-    batch = SimpleBatch(list_samples)
-    labels = batch.get_labels()
-    assert isinstance(labels, list)
-    torch.testing.assert_close(labels[0], torch.tensor([0.0, 1.0], dtype=torch.float32))
-    assert labels[1] == 1
-    assert labels[2] is None
+    out = tuple_collate_fn(list(zip(list_samples, list_samples)))
+    assert isinstance(out, tuple)
+    assert len(out) == 2
+    assert isinstance(out[0], Batch)

--- a/tests/unittests/data/dataloader/test_batch.py
+++ b/tests/unittests/data/dataloader/test_batch.py
@@ -135,7 +135,8 @@ def test_to():
         ]
     )
     with pytest.raises(
-        ValueError, match="If 'device' is a str, it must be like 'cuda:<device-id>'."
+        ValueError,
+        match="If 'device' is a str, it must be 'cuda' or 'cuda:<device-id>'.",
     ):
         batch.to("cuda-0", non_blocking=True)
     batch.to("cuda", non_blocking=True)

--- a/tests/unittests/data/dataloader/test_batch.py
+++ b/tests/unittests/data/dataloader/test_batch.py
@@ -138,8 +138,8 @@ def test_to():
     assert batch_gpu.device == torch.device("cuda:0")
     assert batch.device == torch.device("cpu")
 
-    assert batch["label"].device == torch.device("cpu")
-    assert batch_gpu["label"].device == torch.device("cuda:0")
+    assert batch[0]["label"].device == torch.device("cpu")
+    assert batch_gpu[0]["label"].device == torch.device("cuda:0")
     assert batch.get_field("output").device == torch.device("cpu")
     assert batch_gpu.get_field("output").device == torch.device("cuda:0")
 

--- a/tests/unittests/data/dataloader/test_config.py
+++ b/tests/unittests/data/dataloader/test_config.py
@@ -8,7 +8,7 @@ from pydantic import ValidationError
 from torch.utils.data import DistributedSampler, WeightedRandomSampler
 
 from clinicadl.data.dataloader import DataLoaderConfig
-from clinicadl.data.dataloader.batch import SimpleBatch
+from clinicadl.data.dataloader.batch import Batch
 from clinicadl.data.datasets import (
     CapsDataset,
     ConcatDataset,
@@ -101,7 +101,7 @@ def test_get_object():
     assert dataloader.sampler.num_samples == 7
     assert dataloader.sampler.replacement
     batch = next(iter(dataloader))
-    assert isinstance(batch, SimpleBatch)
+    assert isinstance(batch, Batch)
     assert batch[0].participant == "sub-999"
     assert batch[0].session == "ses-M099"
 
@@ -129,7 +129,7 @@ def test_get_object():
     assert dataloader.sampler.num_replicas == 1
     assert dataloader.sampler.rank == 0
     batch = next(iter(dataloader))
-    assert isinstance(batch, SimpleBatch)
+    assert isinstance(batch, Batch)
     assert batch[0].participant == "sub-000"
     assert batch[0].session == "ses-M000"
 

--- a/tests/unittests/data/dataloader/test_config.py
+++ b/tests/unittests/data/dataloader/test_config.py
@@ -117,8 +117,8 @@ def test_get_object():
     assert isinstance(batch, tuple)
     assert batch[0][0].participant == "sub-100"
     assert batch[0][0].session == "ses-M000"
-    assert batch[0].get_labels() == torch.tensor([5.0])
-    assert batch[1].get_labels() == [None]
+    assert batch[0].get_field("label") == torch.tensor([5.0])
+    assert batch[1].get_field("label") == [None]
 
     dataloader_config = DataLoaderConfig(
         shuffle=False,
@@ -168,14 +168,14 @@ def test_get_object():
     dataloader.set_epoch(5)
     batch = next(iter(dataloader))
     assert isinstance(batch, tuple)
-    assert (batch[0].get_labels() == torch.tensor([1.0, 10.0])).all()
-    assert batch[1].get_labels() == [None, None]
+    assert (batch[0].get_field("label") == torch.tensor([1.0, 10.0])).all()
+    assert batch[1].get_field("label") == [None, None]
 
     dataloader = DataLoaderConfig(batch_size=5, shuffle=True).get_object(
         ConcatDataset([CAPS, CAPS_WITHOUT_LABEL])
     )
     batch = next(iter(dataloader))
-    assert batch.get_labels() == [5.0, 1.0, None, 10.0, 1.0]
+    assert batch.get_field("label") == [5.0, 1.0, None, 10.0, 1.0]
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Some updates on the ``SimpleBatch`` object:

- renamed to ``Batch``;
- ``get_images`` and ``get_labels`` have been merged to a common method ``get_field``, that enables to access any field of the ``DataPoint`` in the batch;
- a new ``to`` method that enables to send the batch on an other device.

Tests and documentation have been updated accordingly.