### PR TITLE
Fix slice squeezing issue

### DIFF
--- a/clinicadl/data/dataloader/batch.py
+++ b/clinicadl/data/dataloader/batch.py
@@ -223,8 +223,12 @@ class Batch(list[DataPoint]):
             for datapoint in self:
                 value = self._get_field(datapoint, field_name)
 
-                if isinstance(datapoint, SliceSample) and datapoint.squeeze:
-                    squeezed_dim = datapoint.slice_direction
+                if (
+                    hasattr(datapoint, "squeeze")
+                    and hasattr(datapoint, "slice_direction")
+                    and getattr(datapoint, "squeeze")
+                ):
+                    squeezed_dim = getattr(datapoint, "slice_direction")
                 else:
                     squeezed_dim = None
 

--- a/clinicadl/data/dataloader/batch.py
+++ b/clinicadl/data/dataloader/batch.py
@@ -8,7 +8,6 @@ import torch
 import torchio as tio
 
 from clinicadl.data.structures import DataPoint
-from clinicadl.transforms.extraction.slice import SliceSample
 from clinicadl.utils.device import DeviceType, check_device
 
 

--- a/clinicadl/data/datasets/caps_dataset.py
+++ b/clinicadl/data/datasets/caps_dataset.py
@@ -890,7 +890,7 @@ class CapsDataset(Dataset):
         if not self._tensor_conversion_info.transforms:  # image transforms not saved
             data = self.transforms.apply_image_transforms(data)
 
-        data = self.extraction.extract_sample(data, sample_index)
+        data = self.transforms.extract_sample(data, sample_index)
 
         data = self.transforms.apply_sample_transforms(data)
 

--- a/clinicadl/transforms/handlers/transforms.py
+++ b/clinicadl/transforms/handlers/transforms.py
@@ -177,6 +177,14 @@ class Transforms(TransformsHandler):
         """
         return self._image_transforms_processed(datapoint)
 
+    def extract_sample(self, datapoint: DataPoint, sample_index: int) -> DataPoint:
+        """
+        Extracts the sample.
+
+        See: :py:class:`clinicadl.transforms.extraction.Extraction`.
+        """
+        return self.extraction.extract_sample(datapoint, sample_index)
+
     def apply_sample_transforms(self, datapoint: DataPoint) -> DataPoint:
         """
         Applies the transforms passed in ``sample_transforms`` and returns the

--- a/tests/unittests/data/dataloader/test_batch.py
+++ b/tests/unittests/data/dataloader/test_batch.py
@@ -5,7 +5,6 @@ import torchio as tio
 
 from clinicadl.data.dataloader.batch import Batch, simple_collate_fn, tuple_collate_fn
 from clinicadl.data.structures import DataPoint
-from clinicadl.transforms.extraction.slice import SliceSample
 
 
 def test_init():
@@ -96,7 +95,7 @@ def test_get_field():
     # slices
     batch = Batch(
         [
-            SliceSample(
+            DataPoint(
                 image=tio.ScalarImage(tensor=torch.randn(1, 3, 1, 5)),
                 label=tio.LabelMap(tensor=torch.ones(1, 3, 1, 5)),
                 participant=f"sub-{i}",

--- a/tests/unittests/transforms/handlers/test_transforms.py
+++ b/tests/unittests/transforms/handlers/test_transforms.py
@@ -71,7 +71,7 @@ def test_apply_transforms():
     assert data_point.label.tensor.shape == (1, 12, 12, 12)
     assert data_point.mask_1.tensor.shape == (1, 12, 12, 12)
 
-    tio_sample = transforms.extraction.extract_sample(data_point, 0)
+    tio_sample = transforms.extract_sample(data_point, 0)
     patch_mask = np.zeros((1, 4, 4, 4))
     patch_mask[:, 1:, 1:, 1:] = 1
     patch_mask = torch.from_numpy(patch_mask)


### PR DESCRIPTION
Some transforms convert ``SliceSample`` to ``DataPoint``, so the condition ``if isinstance(datapoint, SliceSample)`` is not enough to catch all ``DataPoints`` that contain slices.