### PR TITLE
add .clone() in get_field of Batch

### DIFF
--- a/clinicadl/data/dataloader/batch.py
+++ b/clinicadl/data/dataloader/batch.py
@@ -328,7 +328,7 @@ class Batch(list[DataPoint]):
         Tries to convert to a tensor.
         """
         if isinstance(value, tio.Image):
-            tensor = value.tensor
+            tensor = value.tensor.clone()
             if squeeze_img_dim is not None:
                 tensor.squeeze_(dim=squeeze_img_dim + 1)
 
@@ -342,7 +342,7 @@ class Batch(list[DataPoint]):
         elif isinstance(value, dict):
             return cls._to_tensor(list(value.values()))
         elif isinstance(value, torch.Tensor):
-            return value
+            return value.clone()
         else:
             try:
                 return torch.tensor(value)

--- a/tests/unittests/data/dataloader/test_batch.py
+++ b/tests/unittests/data/dataloader/test_batch.py
@@ -114,6 +114,7 @@ def test_get_field():
     assert images.size() == (2, 1, 3, 5)
     labels = batch.get_field("label")
     assert labels.size() == (2, 1, 3, 5)
+    assert batch[0].image.tensor.shape == (1, 3, 1, 5)
 
     # errors
     with pytest.raises(


### PR DESCRIPTION
Previously, the tensor inside the ``torchio.Image`` was squeezed because of the in-place operation ``squeeze_``.