### PR TITLE
Trainer divers fix

### DIFF
--- a/clinicadl/callbacks/factory/lr_scheduler.py
+++ b/clinicadl/callbacks/factory/lr_scheduler.py
@@ -11,7 +11,10 @@ from clinicadl.optim.lr_schedulers.config import (
 )
 from clinicadl.optim.lr_schedulers.config import LRSchedulerType as LRSchedulerMode
 from clinicadl.optim.lr_schedulers.config.factory import get_lr_scheduler_config
-from clinicadl.utils.exceptions import ClinicaDLConfigurationError
+from clinicadl.utils.exceptions import (
+    ClinicaDLArgumentError,
+    ClinicaDLConfigurationError,
+)
 
 from .base import Callback
 
@@ -96,14 +99,15 @@ class LRScheduler(Callback):
     def __init__(
         self,
         scheduler: LRSchedulerType,
-        optimizer: Optional[torch.optim.Optimizer] = None,
+        optimizer_key: str = "optimizer",
         scheduler_type: Optional[LRSchedulerMode] = None,
         **kwargs,
     ):
         self.config: Optional[LRSchedulerConfig] = None
-        self.scheduler: torch.optim.lr_scheduler.LRScheduler
+        self.scheduler: Optional[torch.optim.lr_scheduler.LRScheduler] = None
+        self.optimizer_key = optimizer_key
         self.scheduler_type: LRSchedulerType
-        self._initial_state: dict
+        self._initial_state: Optional[dict] = None
 
         if isinstance(scheduler, torch.optim.lr_scheduler.LRScheduler):
             self.scheduler = scheduler
@@ -112,6 +116,7 @@ class LRScheduler(Callback):
                     "If you pass directly your own LRScheduler, you must must specify the type of scheduler via 'scheduler_type'."
                 )
             self.scheduler_type = LRSchedulerMode(scheduler_type)
+            self._initial_state = self.scheduler.state_dict()
 
         else:
             if isinstance(scheduler, str):
@@ -129,28 +134,30 @@ class LRScheduler(Callback):
                     f"Expected LRSchedulerConfig, ImplementedLRScheduler or torch.optim.lr_scheduler.LRScheduler"
                 )
 
-            if not optimizer:
-                raise ValueError(
-                    "If you pass a LRScheduler via a name or a config class, you must also pass the associated optimizer via 'optimizer'."
-                )
-
-            self.scheduler = self.config.get_object(optimizer)
             self.scheduler_type = self.config.scheduler_type()
-
-        self._initial_state = self.scheduler.state_dict()
 
     def on_train_begin(self, config: _TrainingState, **kwargs) -> None:
         """
-        Checks the optimizer and resets the LR scheduler.
+        Checks the optimizer_key and instantiates the LR scheduler.
         """
         optimizers = config.model.get_optimizers()
-        if self.scheduler.optimizer not in optimizers.values():
-            raise ClinicaDLConfigurationError(
-                f"The optimizer associated to the LR scheduler '{type(self.scheduler).__name__}' is not an optimizer returned by your ClinicaDLModel via the "
-                "method 'get_optimizers'. There is therefore a risk that this optimizer is not used during training."
-            )
+        try:
+            optimizer = optimizers[self.optimizer_key]
+        except KeyError as exc:
+            raise ClinicaDLArgumentError(
+                f"In LRScheduler, optimizer_key='{self.optimizer_key}' but there is no such optimizer (returned by the 'get_optimizers' method of you ClinicaDLModel). "
+                f"Optimizers are: {list(optimizers.keys())}"
+            ) from exc
 
-        self.scheduler.load_state_dict(self._initial_state)
+        if self.config:
+            self.scheduler = self.config.get_object(optimizer)
+        else:
+            if optimizer is not self.scheduler.optimizer:
+                raise ClinicaDLConfigurationError(
+                    f"The optimizer associated to the LR scheduler '{type(self.scheduler).__name__}' is not the same as "
+                    f"'{self.optimizer_key}' (returned by the 'get_optimizers' method of you ClinicaDLModel)."
+                )
+            self.scheduler.load_state_dict(self._initial_state)
 
     def on_batch_end(self, config: _TrainingState, **kwargs) -> None:
         """

--- a/clinicadl/callbacks/factory/lr_scheduler.py
+++ b/clinicadl/callbacks/factory/lr_scheduler.py
@@ -46,15 +46,15 @@ class LRScheduler(Callback):
     ----------
     scheduler : Union[str, ImplementedLRScheduler, LRSchedulerConfig, torch.optim.lr_scheduler.LRScheduler]
         The learning rate scheduler configuration or object. Can be:
-    optimizer : Optional[torch.optim.Optimizer], default=None
+    optimizer : str, default="optimizer"
         The optimizer associated to the LR scheduler. **Mandatory if a name or a config class
         is passed to** ``scheduler``.
     scheduler_type : Optional[LRSchedulerMode], default=None
         The type of LR scheduler, among:
 
         - ``"epoch-based"``: learning rate is updated at the end of the epoch (e.g. :py:class:`~torch.optim.lr_scheduler.LinearLR`);
-        - ``"loss-based"``: learning rate is updated at the end of the epoch according
-          to the validation loss (e.g. :py:class:`~torch.optim.lr_scheduler.ReduceLROnPlateau`);
+        - ``"metric-based"``: learning rate is updated at the end of the epoch according
+          to a validation metric (e.g. :py:class:`~torch.optim.lr_scheduler.ReduceLROnPlateau`);
         - ``"step-based"``: learning rate is updated after each optimization step
           (e.g. :py:class:`~torch.optim.lr_scheduler.OneCycleLR`).
 
@@ -101,6 +101,7 @@ class LRScheduler(Callback):
         scheduler: LRSchedulerType,
         optimizer_key: str = "optimizer",
         scheduler_type: Optional[LRSchedulerMode] = None,
+        metric: Optional[str] = None,
         **kwargs,
     ):
         self.config: Optional[LRSchedulerConfig] = None
@@ -136,6 +137,13 @@ class LRScheduler(Callback):
 
             self.scheduler_type = self.config.scheduler_type()
 
+        if self.scheduler_type == LRSchedulerMode.METRIC and not metric:
+            raise ClinicaDLConfigurationError(
+                f"If scheduler_type='{LRSchedulerMode.METRIC.value}', you must "
+                "pass the name of the validation metric via 'metric'."
+            )
+        self.metric = metric
+
     def on_train_begin(self, config: _TrainingState, **kwargs) -> None:
         """
         Checks the optimizer_key and instantiates the LR scheduler.
@@ -170,13 +178,13 @@ class LRScheduler(Callback):
     def on_epoch_end(self, config: _TrainingState, **kwargs) -> None:
         """
         Step the learning rate scheduler after each epoch for
-        epoch-based and loss-based schedulers.
+        epoch-based and metric-based schedulers.
         """
         if self.scheduler_type == LRSchedulerMode.EPOCH:
             self.scheduler.step()
-        elif self.scheduler_type == LRSchedulerMode.LOSS:
-            val_loss = config.metrics.get_loss(epoch=config.epoch)
-            self.scheduler.step(val_loss)
+        elif self.scheduler_type == LRSchedulerMode.METRIC:
+            val_metric = config.metrics.get_metric(self.metric, epoch=config.epoch)
+            self.scheduler.step(val_metric)
 
     def save_checkpoint(
         self,

--- a/clinicadl/callbacks/factory/lr_scheduler.py
+++ b/clinicadl/callbacks/factory/lr_scheduler.py
@@ -99,14 +99,14 @@ class LRScheduler(Callback):
     def __init__(
         self,
         scheduler: LRSchedulerType,
-        optimizer_key: str = "optimizer",
+        optimizer_name: str = "optimizer",
         scheduler_type: Optional[LRSchedulerMode] = None,
-        metric: Optional[str] = None,
+        metric_name: Optional[str] = None,
         **kwargs,
     ):
         self.config: Optional[LRSchedulerConfig] = None
         self.scheduler: Optional[torch.optim.lr_scheduler.LRScheduler] = None
-        self.optimizer_key = optimizer_key
+        self.optimizer_name = optimizer_name
         self.scheduler_type: LRSchedulerType
         self._initial_state: Optional[dict] = None
 
@@ -137,23 +137,23 @@ class LRScheduler(Callback):
 
             self.scheduler_type = self.config.scheduler_type()
 
-        if self.scheduler_type == LRSchedulerMode.METRIC and not metric:
+        if self.scheduler_type == LRSchedulerMode.METRIC and not metric_name:
             raise ClinicaDLConfigurationError(
                 f"If scheduler_type='{LRSchedulerMode.METRIC.value}', you must "
-                "pass the name of the validation metric via 'metric'."
+                "pass the name of the validation metric via 'metric_name'."
             )
-        self.metric = metric
+        self.metric_name = metric_name
 
     def on_train_begin(self, config: _TrainingState, **kwargs) -> None:
         """
-        Checks the optimizer_key and instantiates the LR scheduler.
+        Checks the optimizer_name and instantiates the LR scheduler.
         """
         optimizers = config.model.get_optimizers()
         try:
-            optimizer = optimizers[self.optimizer_key]
+            optimizer = optimizers[self.optimizer_name]
         except KeyError as exc:
             raise ClinicaDLArgumentError(
-                f"In LRScheduler, optimizer_key='{self.optimizer_key}' but there is no such optimizer (returned by the 'get_optimizers' method of you ClinicaDLModel). "
+                f"In LRScheduler, optimizer_name='{self.optimizer_name}' but there is no such optimizer (returned by the 'get_optimizers' method of you ClinicaDLModel). "
                 f"Optimizers are: {list(optimizers.keys())}"
             ) from exc
 
@@ -163,7 +163,7 @@ class LRScheduler(Callback):
             if optimizer is not self.scheduler.optimizer:
                 raise ClinicaDLConfigurationError(
                     f"The optimizer associated to the LR scheduler '{type(self.scheduler).__name__}' is not the same as "
-                    f"'{self.optimizer_key}' (returned by the 'get_optimizers' method of you ClinicaDLModel)."
+                    f"'{self.optimizer_name}' (returned by the 'get_optimizers' method of you ClinicaDLModel)."
                 )
             self.scheduler.load_state_dict(self._initial_state)
 
@@ -183,7 +183,7 @@ class LRScheduler(Callback):
         if self.scheduler_type == LRSchedulerMode.EPOCH:
             self.scheduler.step()
         elif self.scheduler_type == LRSchedulerMode.METRIC:
-            val_metric = config.metrics.get_metric(self.metric, epoch=config.epoch)
+            val_metric = config.metrics.get_metric(self.metric_name, epoch=config.epoch)
             self.scheduler.step(val_metric)
 
     def save_checkpoint(

--- a/clinicadl/metrics/base.py
+++ b/clinicadl/metrics/base.py
@@ -15,7 +15,6 @@ import torch
 from monai.metrics.metric import CumulativeIterationMetric
 
 from clinicadl.data.dataloader import Batch
-from clinicadl.data.structures import DataPoint
 
 from .enum import Optimum
 

--- a/clinicadl/metrics/config/__init__.py
+++ b/clinicadl/metrics/config/__init__.py
@@ -1,11 +1,12 @@
 """Config classes metrics natively supported in ``ClinicaDL``. Based on
 :monai:`MONAI metrics <metrics.html>`."""
 
-from .base import LossMetricConfig, MetricConfig
+from .base import MetricConfig
 from .classification import *
 from .custom import CustomMetric
 from .enum import ImplementedMetric
 from .factory import get_metric_config
+from .loss import LossMetricConfig
 from .reconstruction import *
 from .regression import *
 from .segmentation import *

--- a/clinicadl/metrics/config/base.py
+++ b/clinicadl/metrics/config/base.py
@@ -1,26 +1,21 @@
 from abc import abstractmethod
 from logging import getLogger
-from typing import Any, Dict, Optional
+from typing import Optional
 
 import monai.metrics
-from pydantic import field_validator, model_validator
+from pydantic import field_validator
 
 from clinicadl.dictionary.words import LABEL, NAME, OUTPUT
-from clinicadl.losses.enum import Reduction
-from clinicadl.losses.types import Loss
 from clinicadl.transforms.types import TransformOrConfig
 from clinicadl.utils.config import ClinicaDLConfig, ObjectConfig
-from clinicadl.utils.factories import get_defaults_from
 
 from ..base import Metric
 from ..enum import Optimum
 from ..monai_wrapper import MonaiMetricWrapper
 
-__all__ = ["MetricConfig", "LossMetricConfig"]
+__all__ = ["MetricConfig"]
 
 logger = getLogger("clinicadl.metrics")
-
-LOSS_METRIC_MONAI_DEFAULTS = get_defaults_from(monai.metrics.LossMetric)
 
 
 class MetricConfig(ObjectConfig):
@@ -76,40 +71,3 @@ class _GetNotNansConfig(ClinicaDLConfig):
         ), "'get_not_nans' currently not supported in ClinicaDL. Please leave to False."
 
         return v
-
-
-class LossMetricConfig(MetricConfig):
-    "Config class to use the loss as a metric."
-
-    loss_fn: Loss
-    reduction: Reduction = LOSS_METRIC_MONAI_DEFAULTS["reduction"]
-
-    @staticmethod
-    def optimum() -> Optimum:
-        """The optimum of the metric."""
-        return Optimum.MIN
-
-    @model_validator(mode="after")
-    def check_reduction(self):
-        """Removes the reduction of the loss, and add it at the metric level."""
-        try:
-            loss_reduction = getattr(self.loss_fn, "reduction")
-        except AttributeError:
-            pass
-        else:
-            if self.reduction != loss_reduction:
-                logger.warning(
-                    f"The loss ({type(self.loss_fn).__name__}) has '{loss_reduction}' reduction, "
-                    f"whereas in the metric associated to the loss you passed '{self.reduction}' reduction."
-                )
-            setattr(self.loss_fn, "reduction", "none")
-
-        return self
-
-    def to_dict(self) -> Dict[str, Any]:
-        from clinicadl.utils.json import serialize_callable
-
-        my_dict = super().to_dict()
-        my_dict["loss_fn"] = serialize_callable(self.loss_fn)
-
-        return my_dict

--- a/clinicadl/metrics/config/factory.py
+++ b/clinicadl/metrics/config/factory.py
@@ -1,13 +1,14 @@
 from typing import Any, Union
 
 # pylint: disable=unused-import
-from .base import LossMetricConfig, MetricConfig
+from .base import MetricConfig
 from .classification import (
     AveragePrecisionMetricConfig,
     ConfusionMatrixMetricConfig,
     ROCAUCMetricConfig,
 )
 from .enum import ImplementedMetric
+from .loss import LossMetricConfig
 from .reconstruction import (
     MultiScaleSSIMMetricConfig,
     PSNRMetricConfig,

--- a/clinicadl/metrics/config/loss.py
+++ b/clinicadl/metrics/config/loss.py
@@ -26,7 +26,7 @@ LOSS_METRIC_MONAI_DEFAULTS = get_defaults_from(LossMetric)
 class LossMetricConfig(MetricConfig, _GetNotNansConfig):
     """Special config class to use a loss function as a metric."""
 
-    loss_key: str = "loss"
+    loss_name: str = "loss"
 
     @staticmethod
     def optimum() -> Optimum:
@@ -50,10 +50,10 @@ class LossMetricConfig(MetricConfig, _GetNotNansConfig):
         """
         losses = model.get_loss_functions()
         try:
-            loss = losses[self.loss_key]
+            loss = losses[self.loss_name]
         except KeyError as exc:
             raise ClinicaDLArgumentError(
-                f"In LossMetricConfig, loss_key='{self.loss_key}' but there is no such loss (returned by the 'get_loss_functions' method of you ClinicaDLModel). "
+                f"In LossMetricConfig, loss_name='{self.loss_name}' but there is no such loss (returned by the 'get_loss_functions' method of you ClinicaDLModel). "
                 f"Losses are: {list(losses.keys())}"
             ) from exc
 
@@ -77,7 +77,7 @@ class LossMetricConfig(MetricConfig, _GetNotNansConfig):
             loss_reduction = getattr(loss, "reduction")
         except AttributeError as exc:
             raise ClinicaDLArgumentError(
-                f"The loss '{self.loss_key}' (returned by the 'get_loss_functions' method of you ClinicaDLModel) "
+                f"The loss '{self.loss_name}' (returned by the 'get_loss_functions' method of you ClinicaDLModel) "
                 "doesn't have a 'reduction' attribute, so ClinicaDL can't compute the validation loss at the image level."
             ) from exc
 

--- a/clinicadl/metrics/config/loss.py
+++ b/clinicadl/metrics/config/loss.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from logging import getLogger
+from typing import TYPE_CHECKING
+
+from monai.metrics import LossMetric
+
+from clinicadl.losses.types import Loss
+from clinicadl.utils.exceptions import ClinicaDLArgumentError
+from clinicadl.utils.factories import get_defaults_from
+
+from ..base import Metric
+from ..enum import Optimum
+from ..monai_wrapper import MonaiMetricWrapper
+from .base import MetricConfig, _GetNotNansConfig
+
+if TYPE_CHECKING:
+    from clinicadl.models import ClinicaDLModel
+
+logger = getLogger("clinicadl.metrics.loss")
+
+LOSS_METRIC_MONAI_DEFAULTS = get_defaults_from(LossMetric)
+
+
+class LossMetricConfig(MetricConfig, _GetNotNansConfig):
+    """Special config class to use a loss function as a metric."""
+
+    loss_key: str = "loss"
+
+    @staticmethod
+    def optimum() -> Optimum:
+        """The optimum of the metric."""
+        return Optimum.MIN
+
+    def get_object(self, model: ClinicaDLModel) -> Metric:
+        """
+        Returns the metric associated to this configuration,
+        parametrized with the parameters passed by the user.
+
+        Parameters
+        ----------
+        model : ClinicaDLModel
+            The :py:class:`clinicadl.model.ClinicaDLModel` where the loss is.
+
+        Returns
+        -------
+        Metric:
+            The associated metric.
+        """
+        losses = model.get_loss_functions()
+        try:
+            loss = losses[self.loss_key]
+        except KeyError as exc:
+            raise ClinicaDLArgumentError(
+                f"In LossMetricConfig, loss_key='{self.loss_key}' but there is no such loss (returned by the 'get_loss_functions' method of you ClinicaDLModel). "
+                f"Losses are: {list(losses.keys())}"
+            ) from exc
+
+        loss, reduction = self._check_reduction(loss)
+
+        monai_metric = LossMetric(
+            loss_fn=loss, reduction=reduction, get_not_nans=self.get_not_nans
+        )
+        metric = MonaiMetricWrapper(
+            monai_metric,
+            pred_key=self.pred_key,
+            label_key=self.label_key,
+            optimum=self.optimum(),
+            postprocessing=self.postprocessing,
+        )
+        return metric
+
+    def _check_reduction(self, loss: Loss) -> tuple[Loss, str]:
+        """Remove the reduction of the loss to put it at the metric level."""
+        try:
+            loss_reduction = getattr(loss, "reduction")
+        except AttributeError as exc:
+            raise ClinicaDLArgumentError(
+                f"The loss '{self.loss_key}' (returned by the 'get_loss_functions' method of you ClinicaDLModel) "
+                "doesn't have a 'reduction' attribute, so ClinicaDL can't compute the validation loss at the image level."
+            ) from exc
+
+        loss = deepcopy(loss)
+        setattr(loss, "reduction", "none")
+
+        return loss, loss_reduction

--- a/clinicadl/metrics/handler.py
+++ b/clinicadl/metrics/handler.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from copy import deepcopy
 from pathlib import Path
-from typing import Dict, Optional, Union
+from typing import TYPE_CHECKING, Dict, Optional, Union
 
 import pandas as pd
 from pydantic import field_serializer
@@ -11,7 +10,6 @@ from clinicadl.data.dataloader import Batch
 from clinicadl.dictionary.utils import SEP
 from clinicadl.dictionary.words import (
     EPOCH,
-    LOSS,
     PARTICIPANT,
     PARTICIPANT_ID,
     SESSION,
@@ -19,14 +17,18 @@ from clinicadl.dictionary.words import (
 )
 from clinicadl.metrics.config import LossMetricConfig, MetricConfig, get_metric_config
 from clinicadl.utils.config import ClinicaDLConfig
+from clinicadl.utils.exceptions import ClinicaDLConfigurationError
 
 from .base import Metric
 from .types import MetricOrConfig
 
+if TYPE_CHECKING:
+    from clinicadl.models import ClinicaDLModel
+
 CUSTOM_METRIC = "Custom metric passed by the user"
 
 
-class _MetricProcessor(ClinicaDLConfig):
+class MetricsHandlerConfig(ClinicaDLConfig):
     """
     To check and convert metrics passed by the user.
     """
@@ -52,7 +54,7 @@ class _MetricProcessor(ClinicaDLConfig):
         return repr_
 
     @classmethod
-    def from_json(cls, json_path: Path, **kwargs) -> _MetricProcessor:
+    def from_json(cls, json_path: Path, **kwargs) -> MetricsHandlerConfig:
         """
         Reads the serialized config class from a JSON file.
         """
@@ -70,16 +72,18 @@ class _MetricProcessor(ClinicaDLConfig):
                         f"{name}=<your-custom-metric>"
                     )
 
-        return _MetricProcessor(metrics=dict_)
+        return MetricsHandlerConfig(metrics=dict_)
 
-    def get_callable_metrics(self) -> dict[str, Metric]:
+    def get_callable_metrics(self, model: ClinicaDLModel) -> dict[str, Metric]:
         """
         Gets the callable metrics.
         """
         callable_metrics: Dict[str, Metric] = {}
 
         for name, metric in self.metrics.items():
-            if isinstance(metric, MetricConfig):
+            if isinstance(metric, LossMetricConfig):
+                callable_metrics[name] = metric.get_object(model)
+            elif isinstance(metric, MetricConfig):
                 callable_metrics[name] = metric.get_object()
             else:
                 callable_metrics[name] = metric
@@ -116,9 +120,6 @@ class MetricsHandler:
 
     Parameters
     ----------
-    loss : Optional[LossMetricConfig], default=None
-        A loss to add to the metrics. It must be passed via
-        :py:class:`clinicadl.metrics.config.LossMetricConfig`.
     **metrics : MetricConfig
         Metrics to add to the MetricsHandler. They must be passed as
         :py:class:`clinicadl.metrics.config.MetricConfig` or :py:class:`clinicadl.metrics.Metric`.
@@ -126,21 +127,35 @@ class MetricsHandler:
 
     def __init__(
         self,
-        loss: Optional[LossMetricConfig] = None,
         **metrics: MetricOrConfig,
     ):
         if not metrics:
             metrics = {}
 
-        self._metrics_processor = _MetricProcessor(metrics=metrics)
-        self.metrics = deepcopy(self._metrics_processor.metrics)
-        self._callable_metrics = self._metrics_processor.get_callable_metrics()
-
-        if loss:
-            self._add_loss(loss)
+        self.config = MetricsHandlerConfig(metrics=metrics)
+        self._callable_metrics = None
+        self._model = None
 
         self._df = self._init_df()
         self._detailed_df = self._init_detailed_df()
+
+    def init_metrics(self, model: ClinicaDLModel) -> None:
+        """
+        Instantiates the metrics from their config classes.
+
+        Parameters
+        ----------
+        model : ClinicaDLModel
+            The model that contains the potential losses to compute
+            on the validation set.
+        """
+        self._callable_metrics = self.config.get_callable_metrics(model)
+        self._model = model
+
+    @property
+    def metrics(self):
+        """The metrics currently in the MetricsHandler."""
+        return self.config.metrics
 
     @property
     def df(self) -> pd.DataFrame:
@@ -175,7 +190,6 @@ class MetricsHandler:
 
     def add_metrics(
         self,
-        loss: Optional[LossMetricConfig] = None,
         **metrics: MetricOrConfig,
     ) -> None:
         """
@@ -183,25 +197,24 @@ class MetricsHandler:
 
         Parameters
         ----------
-        loss : Optional[LossMetricConfig], default=None
-            A loss to add to the metrics. It must be passed via
-            :py:class:`clinicadl.metrics.config.LossMetricConfig`.
         **metrics : MetricConfig
             Metrics to add to the MetricsHandler. They must be passed as
             :py:class:`clinicadl.metrics.config.MetricConfig` or :py:class:`clinicadl.metrics.Metric`.
         """
-        self._metrics_processor.add_metrics(metrics)
-        self.metrics = self._metrics_processor.metrics
-        self._callable_metrics = self._metrics_processor.get_callable_metrics()
+        self.config.add_metrics(metrics)
+        if self._callable_metrics is not None:
+            self._callable_metrics = self.config.get_callable_metrics(self._model)
 
-        if loss:
-            self._add_loss(loss=loss)
+        new_columns = self._df.columns.union(self.metrics.keys())
+        self._df = self._df.reindex(columns=new_columns, fill_value=pd.NA)
 
-        self._df = self._df.reindex(
-            columns=self._df.columns.union(self.metrics.keys()), fill_value=pd.NA
-        )
+        new_columns = (
+            self._detailed_df.columns.drop([PARTICIPANT_ID, SESSION_ID])
+            .union(self.metrics.keys())
+            .union([PARTICIPANT_ID, SESSION_ID])
+        )  # we want participant and session at the end
         self._detailed_df = self._detailed_df.reindex(
-            columns=self._detailed_df.columns.union(self.metrics.keys()),
+            columns=new_columns,
             fill_value=pd.NA,
         )
 
@@ -218,8 +231,9 @@ class MetricsHandler:
         --------
         :py:meth:`monai.metrics.Cumulative.reset`
         """
-        for metric in self._callable_metrics.values():
-            metric.reset()
+        if self._callable_metrics is not None:
+            for metric in self._callable_metrics.values():
+                metric.reset()
 
         if reset_df:
             self._df = self._init_df()
@@ -238,6 +252,11 @@ class MetricsHandler:
         --------
         :py:meth:`monai.metrics.Cumulative.aggregate`
         """
+        if self._callable_metrics is None:
+            raise ClinicaDLConfigurationError(
+                "First, call 'init_metrics' to instantiate the metrics."
+            )
+
         values = {}
         for name, metric in self._callable_metrics.items():
             values[name] = metric.aggregate()
@@ -265,6 +284,11 @@ class MetricsHandler:
         epoch : Optional[int], default=None
             Current epoch. This information will be added in the DataFrame.
         """
+        if self._callable_metrics is None:
+            raise ClinicaDLConfigurationError(
+                "First, call 'init_metrics' to instantiate the metrics."
+            )
+
         participants = batch.get_field(PARTICIPANT)
         sessions = batch.get_field(SESSION)
 
@@ -306,23 +330,6 @@ class MetricsHandler:
             return self.df.set_index(EPOCH).loc[epoch, metric]
         else:
             return self.df.iloc[-1][metric]
-
-    def get_loss(self, epoch: Optional[int] = None) -> float:
-        """
-        To get the value of the loss.
-
-        Parameters
-        ----------
-        epoch : Optional[int], default=None
-            The epoch for which the loss is wanted. If ``None``, the method will
-            return the last computed loss.
-
-        Returns
-        -------
-        float
-            The value of the loss.
-        """
-        return self.get_metric(LOSS, epoch)
 
     def save(self, path: Path, details_path: Optional[Path] = None) -> None:
         """
@@ -374,21 +381,17 @@ class MetricsHandler:
         """
         Save the configuration to a JSON file.
 
-        .. note::
-            The loss metric is not saved in this file.
-
         Parameters
         ----------
         json_path : Path
             Destination file path.
         """
-        self._metrics_processor.write_json(json_path)
+        self.config.write_json(json_path)
 
     @classmethod
     def from_json(
         cls,
         json_path: Path,
-        loss: Optional[LossMetricConfig] = None,
         **metrics: MetricConfig,
     ) -> MetricsHandler:
         """
@@ -398,25 +401,9 @@ class MetricsHandler:
         ----------
         json_path : Path
             Path to the JSON file.
-        loss : Optional[LossMetricConfig], default=None
-            A loss to add to the metrics. Indeed, the loss is not save in the JSON file by
-            :py:meth:`write_json`.
         **metrics : MetricConfig
             Other metrics to add in the MetricsHandler. It is also a way to pass a custom
             metric that otherwise cannot be read in the JSON file.
         """
-        metrics_processor = _MetricProcessor.from_json(json_path, **metrics)
-        return cls(loss=loss, **metrics_processor.metrics)
-
-    def _add_loss(self, loss: LossMetricConfig) -> None:
-        """
-        To add the loss to the metrics.
-        """
-        if LOSS in self.metrics:
-            raise ValueError("You already passed a loss!")
-        if not isinstance(loss, LossMetricConfig):
-            raise ValueError(
-                f"Loss must be passed as a LossMetricConfig. Got {type(loss).__name__}"
-            )
-        self.metrics[LOSS] = loss
-        self._callable_metrics[LOSS] = loss.get_object()
+        metrics_processor = MetricsHandlerConfig.from_json(json_path, **metrics)
+        return cls(**metrics_processor.metrics)

--- a/clinicadl/metrics/handler.py
+++ b/clinicadl/metrics/handler.py
@@ -322,7 +322,7 @@ class MetricsHandler:
         float
             The value of the loss.
         """
-        return self.get_metric("loss", epoch)
+        return self.get_metric(LOSS, epoch)
 
     def save(self, path: Path, details_path: Optional[Path] = None) -> None:
         """

--- a/clinicadl/models/base.py
+++ b/clinicadl/models/base.py
@@ -9,6 +9,7 @@ import torch.optim as optim
 from torch.amp import GradScaler
 
 from clinicadl.data.dataloader import Batch, BatchType
+from clinicadl.losses import Loss
 from clinicadl.utils.device import DeviceType
 from clinicadl.utils.exceptions import NotInterpretableJson
 from clinicadl.utils.json import read_json, write_json
@@ -136,10 +137,35 @@ class ClinicaDLModel(ABC):
 
         All optimizers must be given a name.
 
+        This methods enables ClinicaDL to perform operations
+        on your optimizers, such as :torch:`learning rate scheduling <optim.html#how-to-adjust-learning-rate>`.
+
         Returns
         -------
         dict[str, optim.Optimizer]
             The optimizers and their names.
+        """
+
+    @abstractmethod
+    def get_loss_functions(self) -> dict[str, Loss]:
+        """
+        To retrieve loss functions used during training.
+
+        All loss functions must be given a name.
+
+        This method enables ClinicaDL to compute to compute losses
+        on the validation set.
+
+        .. important::
+            All loss functions must have a :torch:`PyTorch style <nn.html#loss-functions>`,
+            with an attribute named ``reduction`` that can be set to ``none`` in order to
+            compute the validation loss at the image level. Otherwise, the reduction is done
+            at the batch level, so image-level results are not accessible.
+
+        Returns
+        -------
+        dict[str, Loss]
+            The loss functions, as callable that returns a :py:class:`torch.Tensor`, and their names.
         """
 
     @abstractmethod

--- a/clinicadl/models/base.py
+++ b/clinicadl/models/base.py
@@ -33,6 +33,7 @@ class ClinicaDLModel(ABC):
     - :py:meth:`optimization_step`: defines the optimization logic;
     - :py:meth:`evaluation_step`: defines the evaluation logic;
     - :py:meth:`get_optimizers`: to access the optimizers used for training;
+    - :py:meth:`get_loss_functions`: to access the loss functions used during training;
     - :py:meth:`to`: to move the model on a specific device and/or cast the model to a specific datatype and/or memory format;
     - :py:meth:`train`: to set the model in training mode;
     - :py:meth:`eval`: to set the model in evaluation mode;
@@ -137,7 +138,7 @@ class ClinicaDLModel(ABC):
 
         All optimizers must be given a name.
 
-        This methods enables ClinicaDL to perform operations
+        This methods enables ``ClinicaDL`` to perform operations
         on your optimizers, such as :torch:`learning rate scheduling <optim.html#how-to-adjust-learning-rate>`.
 
         Returns
@@ -153,19 +154,18 @@ class ClinicaDLModel(ABC):
 
         All loss functions must be given a name.
 
-        This method enables ClinicaDL to compute to compute losses
-        on the validation set.
+        This method enables ``ClinicaDL`` to compute losses on the validation set.
 
         .. important::
-            All loss functions must have a :torch:`PyTorch style <nn.html#loss-functions>`,
-            with an attribute named ``reduction`` that can be set to ``none`` in order to
-            compute the validation loss at the image level. Otherwise, the reduction is done
-            at the batch level, so image-level results are not accessible.
+            All loss functions must have a :torch:`PyTorch style <nn.html#loss-functions>`, i.e. a
+            callable that returns a :py:class:`torch.Tensor` and with an attribute named ``reduction``
+            that can be set to ``"none"`` in order to compute the validation loss at the image level
+            (otherwise, the reduction is done at the batch level, so image-level results are not accessible).
 
         Returns
         -------
         dict[str, Loss]
-            The loss functions, as callable that returns a :py:class:`torch.Tensor`, and their names.
+            The loss functions and their names.
         """
 
     @abstractmethod

--- a/clinicadl/models/reconstruction.py
+++ b/clinicadl/models/reconstruction.py
@@ -18,7 +18,7 @@ class ReconstructionModelConfig(SupervisedModelConfig):
     """
 
     @classmethod
-    def _get_class(cls) -> type[clinicaDLModel]:
+    def _get_class(cls) -> type[ClinicaDLModel]:
         """Returns the class associated to this config class."""
         return ReconstructionModel
 

--- a/clinicadl/models/supervised.py
+++ b/clinicadl/models/supervised.py
@@ -180,13 +180,13 @@ class SupervisedModel(ClinicaDLModel):
 
     def get_loss_functions(self) -> dict[str, Loss]:
         """
-        Returns the loss functions that will be computed
+        Returns the loss function, that will be computed
         on the validation set.
 
         Returns
         -------
         dict[str, Loss]
-            The loss function named 'loss'.
+            The loss function, named ``"loss"``.
         """
         return {"loss": self.loss}
 
@@ -197,7 +197,7 @@ class SupervisedModel(ClinicaDLModel):
         Returns
         -------
         dict[str, optim.Optimizer]
-            The optimizer named 'optimizer'.
+            The optimizer, named ``"optimizer"``.
         """
         return {"optimizer": self.optimizer}
 

--- a/clinicadl/models/supervised.py
+++ b/clinicadl/models/supervised.py
@@ -77,6 +77,11 @@ class SupervisedModel(ClinicaDLModel):
     loss : LossOrConfig
         The loss function, passed as a ``callable``, that returns a **1-item** :py:class:`~torch.Tensor`,
         or a :py:mod:`config class <clinicadl.losses.config>`.
+
+        .. important::
+            The loss function must have a :torch:`PyTorch style <nn.html#loss-functions>`,
+            with an attribute named ``reduction`` that can be set to ``none``.
+
     optimizer : OptimizerOrConfig
         The optimizer, passed as a :py:class:`torch.optim.Optimizer` or
         a :py:mod:`config class <clinicadl.optim.optimizers.config>`.
@@ -173,16 +178,26 @@ class SupervisedModel(ClinicaDLModel):
 
         return batch
 
+    def get_loss_functions(self) -> dict[str, Loss]:
+        """
+        Returns the loss functions that will be computed
+        on the validation set.
+
+        Returns
+        -------
+        dict[str, Loss]
+            The loss function named 'loss'.
+        """
+        return {"loss": self.loss}
+
     def get_optimizers(self) -> dict[str, optim.Optimizer]:
         """
-        To retrieve all optimizers used during training.
-
-        All optimizers must be given a name.
+        Returns the optimizer.
 
         Returns
         -------
         dict[str, optim.Optimizer]
-            The optimizers and their names.
+            The optimizer named 'optimizer'.
         """
         return {"optimizer": self.optimizer}
 

--- a/clinicadl/optim/lr_schedulers/config/base.py
+++ b/clinicadl/optim/lr_schedulers/config/base.py
@@ -21,7 +21,7 @@ class LRSchedulerConfig(ObjectConfig):
     @classmethod
     @abstractmethod
     def scheduler_type(cls) -> LRSchedulerType:
-        """The type of LR scheduler (epoch-based, step-based, or loss-based)."""
+        """The type of LR scheduler (epoch-based, step-based, or metric-based)."""
 
     @classmethod
     def group_validator(cls, v, field_name: str):

--- a/clinicadl/optim/lr_schedulers/config/configs.py
+++ b/clinicadl/optim/lr_schedulers/config/configs.py
@@ -53,7 +53,7 @@ class ConstantLRConfig(LRSchedulerConfig, _LastEpochConfig):
 
     @classmethod
     def scheduler_type(cls) -> LRSchedulerType:
-        """The type of LR scheduler (epoch-based, step-based, or loss-based)."""
+        """The type of LR scheduler (epoch-based, step-based, or metric-based)."""
         return LRSchedulerType.EPOCH
 
 
@@ -67,7 +67,7 @@ class ExponentialLRConfig(LRSchedulerConfig, _LastEpochConfig):
 
     @classmethod
     def scheduler_type(cls) -> LRSchedulerType:
-        """The type of LR scheduler (epoch-based, step-based, or loss-based)."""
+        """The type of LR scheduler (epoch-based, step-based, or metric-based)."""
         return LRSchedulerType.EPOCH
 
 
@@ -83,7 +83,7 @@ class LinearLRConfig(LRSchedulerConfig, _LastEpochConfig):
 
     @classmethod
     def scheduler_type(cls) -> LRSchedulerType:
-        """The type of LR scheduler (epoch-based, step-based, or loss-based)."""
+        """The type of LR scheduler (epoch-based, step-based, or metric-based)."""
         return LRSchedulerType.EPOCH
 
 
@@ -98,7 +98,7 @@ class StepLRConfig(LRSchedulerConfig, _LastEpochConfig):
 
     @classmethod
     def scheduler_type(cls) -> LRSchedulerType:
-        """The type of LR scheduler (epoch-based, step-based, or loss-based)."""
+        """The type of LR scheduler (epoch-based, step-based, or metric-based)."""
         return LRSchedulerType.EPOCH
 
 
@@ -121,7 +121,7 @@ class MultiStepLRConfig(LRSchedulerConfig, _LastEpochConfig):
 
     @classmethod
     def scheduler_type(cls) -> LRSchedulerType:
-        """The type of LR scheduler (epoch-based, step-based, or loss-based)."""
+        """The type of LR scheduler (epoch-based, step-based, or metric-based)."""
         return LRSchedulerType.EPOCH
 
 
@@ -136,7 +136,7 @@ class PolynomialLRConfig(LRSchedulerConfig, _LastEpochConfig):
 
     @classmethod
     def scheduler_type(cls) -> LRSchedulerType:
-        """The type of LR scheduler (epoch-based, step-based, or loss-based)."""
+        """The type of LR scheduler (epoch-based, step-based, or metric-based)."""
         return LRSchedulerType.EPOCH
 
 
@@ -164,8 +164,8 @@ class ReduceLROnPlateauConfig(LRSchedulerConfig):
 
     @classmethod
     def scheduler_type(cls) -> LRSchedulerType:
-        """The type of LR scheduler (epoch-based, step-based, or loss-based)."""
-        return LRSchedulerType.LOSS
+        """The type of LR scheduler (epoch-based, step-based, or metric-based)."""
+        return LRSchedulerType.METRIC
 
 
 class OneCycleLRConfig(LRSchedulerConfig, _LastEpochConfig):
@@ -240,5 +240,5 @@ class OneCycleLRConfig(LRSchedulerConfig, _LastEpochConfig):
 
     @classmethod
     def scheduler_type(cls) -> LRSchedulerType:
-        """The type of LR scheduler (epoch-based, step-based, or loss-based)."""
+        """The type of LR scheduler (epoch-based, step-based, or metric-based)."""
         return LRSchedulerType.STEP

--- a/clinicadl/optim/lr_schedulers/config/enum.py
+++ b/clinicadl/optim/lr_schedulers/config/enum.py
@@ -26,7 +26,7 @@ class LRSchedulerType(str, Enum):
 
     STEP = "step-based"
     EPOCH = "epoch-based"
-    LOSS = "loss-based"
+    METRIC = "metric-based"
 
 
 class Mode(str, Enum):

--- a/clinicadl/train/trainer.py
+++ b/clinicadl/train/trainer.py
@@ -147,7 +147,9 @@ class Trainer:
         maps_path: PathType,
         model: ClinicaDLModel,
         callbacks: Optional[list[Callback]] = None,
-        metrics: Optional[dict[str, MetricOrConfig]] = None,
+        metrics: dict[str, MetricOrConfig] = {
+            "loss": LossMetricConfig(loss_key="loss")
+        },
         optim_config: OptimizationConfig = OptimizationConfig(),
         comp_config: ComputationalConfig = ComputationalConfig(),
         _overwrite: bool = False,
@@ -156,9 +158,7 @@ class Trainer:
     ) -> None:
         maps = Maps(maps_path)
         if not resume:
-            train_metrics = MetricsHandler(
-                loss=LossMetricConfig(loss_fn=model.loss), **metrics
-            )
+            train_metrics = MetricsHandler(**metrics)
 
             self.callbacks = _CallbacksHandler(
                 metrics=train_metrics,

--- a/clinicadl/train/trainer.py
+++ b/clinicadl/train/trainer.py
@@ -148,7 +148,7 @@ class Trainer:
         model: ClinicaDLModel,
         callbacks: Optional[list[Callback]] = None,
         metrics: dict[str, MetricOrConfig] = {
-            "loss": LossMetricConfig(loss_key="loss")
+            "loss": LossMetricConfig(loss_name="loss")
         },
         optim_config: OptimizationConfig = OptimizationConfig(),
         comp_config: ComputationalConfig = ComputationalConfig(),

--- a/clinicadl/train/trainer.py
+++ b/clinicadl/train/trainer.py
@@ -11,6 +11,7 @@ from torch.utils.data import DataLoader
 
 from clinicadl.callbacks.handler import Callback, _CallbacksHandler
 from clinicadl.callbacks.training_state import _TrainingState
+from clinicadl.data.dataloader import Batch, BatchType
 from clinicadl.data.datasets import CapsDataset
 from clinicadl.IO.maps.maps import Maps
 from clinicadl.losses.config import LossConfig
@@ -225,6 +226,7 @@ class Trainer:
             The data split containing training and validation DataLoaders.
         """
         self.model.train()
+        self.model.to(self.config.comp.device)
         split.train_dataset.train()
 
         # if resume:
@@ -236,6 +238,8 @@ class Trainer:
 
             for batch_idx, data in enumerate(split.train_loader):
                 self.on_batch_begin(batch_idx=batch_idx)
+
+                self._send_to_device(data)
 
                 with autocast(device_type=self.comp.device.type, enabled=self.comp.amp):
                     loss = self.model.forward_step(data=data, device=self.comp.device)
@@ -264,6 +268,7 @@ class Trainer:
         Evaluate the model on a validation or test dataset.
         """
         self.model.eval()
+        self.model.to(self.config.comp.device)
         split.val_dataset.eval()
 
         self.callbacks.on_validation_begin(config=self.config)
@@ -272,12 +277,23 @@ class Trainer:
 
         with torch.no_grad():
             for data in split.val_loader:
+                self._send_to_device(data)
                 output_batch = self.model.evaluation_step(data)
                 self.metrics(output_batch, epoch=self.config.epoch)
 
         self.metrics.aggregate(epoch=self.config.epoch)
 
         self.callbacks.on_validation_end(config=self.config)
+
+    def _send_to_device(self, data: BatchType) -> None:
+        """
+        Send the data to the right device.
+        """
+        if isinstance(data, Batch):
+            data.to(self.config.comp.device)
+        else:
+            for batch in data:
+                batch.to(self.config.comp.device)
 
     def on_train_begin(self, split: Split) -> None:
         self.reset(split)

--- a/tests/unittests/callbacks/factory/test_checkpoint_saver.py
+++ b/tests/unittests/callbacks/factory/test_checkpoint_saver.py
@@ -27,6 +27,7 @@ def test_checkpoint_multiple_epochs(tmp_path):
     shutil.copytree(MAPS_DIR, tmp_path / "maps")
     MAPS = Maps(tmp_path / "maps")
     MAPS.load()
+    MAPS.training.splits[1].best_metrics["loss"].remove()
 
     optim = OPTIMIZER.get_object(network=NETWORK.get_object())
     callbacks = _CallbacksHandler(
@@ -45,6 +46,7 @@ def test_checkpoint_multiple_epochs(tmp_path):
         comp=COMP,
     )
     _ts.reset(deepcopy(SPLIT))
+    callbacks.on_train_begin(_ts)
     cs_callback.on_train_begin(_ts)
 
     assert _ts.split

--- a/tests/unittests/callbacks/factory/test_lr_scheduler.py
+++ b/tests/unittests/callbacks/factory/test_lr_scheduler.py
@@ -193,5 +193,6 @@ def test_save_load_checkpoint(tmp_path):
 
     net.to("cuda")
     scheduler = LRScheduler(StepLRConfig(step_size=1), optimizer=optimizer)
+    scheduler.on_train_begin(TRAINING_STATE)
     scheduler.load_checkpoint(tmp_path / "scheduler", device=torch.device("cuda"))
     scheduler.scheduler.state_dict()["_last_lr"] = 0.0006

--- a/tests/unittests/callbacks/factory/test_lr_scheduler.py
+++ b/tests/unittests/callbacks/factory/test_lr_scheduler.py
@@ -187,6 +187,7 @@ def test_save_load_checkpoint(tmp_path):
     scheduler.save_checkpoint(tmp_path / "scheduler")
 
     scheduler = LRScheduler(StepLRConfig(step_size=1), optimizer=optimizer)
+    scheduler.on_train_begin(TRAINING_STATE)
     scheduler.load_checkpoint(tmp_path / "scheduler")
     scheduler.scheduler.state_dict()["_last_lr"] = 0.0006
 

--- a/tests/unittests/callbacks/factory/test_lr_scheduler.py
+++ b/tests/unittests/callbacks/factory/test_lr_scheduler.py
@@ -54,10 +54,12 @@ def test__init__():
     # metric
     with pytest.raises(
         ClinicaDLConfigurationError,
-        match="If scheduler_type='metric-based', you must pass the name of the validation metric via 'metric'.",
+        match="If scheduler_type='metric-based', you must pass the name of the validation metric via 'metric_name'.",
     ):
         LRScheduler(scheduler=raw_scheduler, scheduler_type="metric-based")
-    LRScheduler(scheduler=raw_scheduler, scheduler_type="metric-based", metric="mse")
+    LRScheduler(
+        scheduler=raw_scheduler, scheduler_type="metric-based", metric_name="mse"
+    )
 
 
 def test_on_train_begin():
@@ -67,13 +69,13 @@ def test_on_train_begin():
     scheduler = LRScheduler(
         scheduler=raw_scheduler,
         scheduler_type="epoch-based",
-        optimizer_key="optimizer_",
+        optimizer_name="optimizer_",
     )
     with pytest.raises(
         ClinicaDLArgumentError,
         match=(
             re.escape(
-                "In LRScheduler, optimizer_key='optimizer_' but there is no such optimizer (returned by the 'get_optimizers' method of you ClinicaDLModel). "
+                "In LRScheduler, optimizer_name='optimizer_' but there is no such optimizer (returned by the 'get_optimizers' method of you ClinicaDLModel). "
                 "Optimizers are: ['optimizer']"
             )
         ),
@@ -109,13 +111,13 @@ def test_on_train_begin():
     scheduler = LRScheduler(
         scheduler=raw_scheduler,
         scheduler_type="epoch-based",
-        optimizer_key="optimizer_",
+        optimizer_name="optimizer_",
     )
     with pytest.raises(
         ClinicaDLArgumentError,
         match=(
             re.escape(
-                "In LRScheduler, optimizer_key='optimizer_' but there is no such optimizer (returned by the 'get_optimizers' method of you ClinicaDLModel). "
+                "In LRScheduler, optimizer_name='optimizer_' but there is no such optimizer (returned by the 'get_optimizers' method of you ClinicaDLModel). "
                 "Optimizers are: ['optimizer']"
             )
         ),
@@ -144,7 +146,7 @@ def test_steps_scheduler():
     epoch_scheduler = LRScheduler(StepLRConfig(step_size=1))
     step_scheduler = LRScheduler(sched, scheduler_type="step-based")
     metric_scheduler = LRScheduler(
-        ReduceLROnPlateauConfig(), scheduler_type="metric-based", metric="mse"
+        ReduceLROnPlateauConfig(), scheduler_type="metric-based", metric_name="mse"
     )
 
     epoch_scheduler.on_train_begin(TRAINING_STATE)

--- a/tests/unittests/callbacks/factory/test_lr_scheduler.py
+++ b/tests/unittests/callbacks/factory/test_lr_scheduler.py
@@ -180,6 +180,7 @@ def test_save_load_checkpoint(tmp_path):
     net = NETWORK.get_object()
     optimizer = OPTIMIZER.get_object(net)
     scheduler = LRScheduler(StepLRConfig(step_size=1), optimizer=optimizer)
+    scheduler.on_train_begin(TRAINING_STATE)
 
     optimizer.step()
     scheduler.scheduler.step()

--- a/tests/unittests/callbacks/factory/test_lr_scheduler.py
+++ b/tests/unittests/callbacks/factory/test_lr_scheduler.py
@@ -7,23 +7,12 @@ import pytest
 import torch
 from torch.optim.lr_scheduler import (
     ConstantLR,
-    ExponentialLR,
-    LinearLR,
-    MultiStepLR,
-    OneCycleLR,
-    PolynomialLR,
-    ReduceLROnPlateau,
     StepLR,
 )
 
 from clinicadl.callbacks.factory.lr_scheduler import LRScheduler
 from clinicadl.optim.lr_schedulers.config import (
     ConstantLRConfig,
-    ExponentialLRConfig,
-    LinearLRConfig,
-    MultiStepLRConfig,
-    OneCycleLRConfig,
-    PolynomialLRConfig,
     ReduceLROnPlateauConfig,
     StepLRConfig,
 )
@@ -61,6 +50,14 @@ def test__init__():
     # name
     scheduler_from_name = LRScheduler("ConstantLR")
     assert isinstance(scheduler_from_name.config, ConstantLRConfig)
+
+    # metric
+    with pytest.raises(
+        ClinicaDLConfigurationError,
+        match="If scheduler_type='metric-based', you must pass the name of the validation metric via 'metric'.",
+    ):
+        LRScheduler(scheduler=raw_scheduler, scheduler_type="metric-based")
+    LRScheduler(scheduler=raw_scheduler, scheduler_type="metric-based", metric="mse")
 
 
 def test_on_train_begin():
@@ -141,13 +138,13 @@ def test_on_train_begin():
 
 def test_steps_scheduler():
     TRAINING_STATE.metrics._df = pd.DataFrame(
-        {"epoch": [0], "mse": [1.0], "mae": [1.0], "loss": [0.5]}
+        {"epoch": [0], "mse": [1.1], "loss": [0.5]}
     )
     sched = StepLR(TRAINING_STATE.model.optimizer, step_size=1)
     epoch_scheduler = LRScheduler(StepLRConfig(step_size=1))
     step_scheduler = LRScheduler(sched, scheduler_type="step-based")
     metric_scheduler = LRScheduler(
-        ReduceLROnPlateauConfig(), scheduler_type="loss-based"
+        ReduceLROnPlateauConfig(), scheduler_type="metric-based", metric="mse"
     )
 
     epoch_scheduler.on_train_begin(TRAINING_STATE)
@@ -173,7 +170,7 @@ def test_steps_scheduler():
 
     epoch_scheduler.scheduler.step.assert_called_once()
     step_scheduler.scheduler.step.assert_called_once()
-    metric_scheduler.scheduler.step.assert_called_once()
+    metric_scheduler.scheduler.step.assert_called_once_with(1.1)
 
 
 @pytest.mark.gpu

--- a/tests/unittests/callbacks/factory/test_lr_scheduler.py
+++ b/tests/unittests/callbacks/factory/test_lr_scheduler.py
@@ -1,3 +1,4 @@
+import re
 from copy import deepcopy
 from unittest.mock import MagicMock
 
@@ -26,52 +27,16 @@ from clinicadl.optim.lr_schedulers.config import (
     ReduceLROnPlateauConfig,
     StepLRConfig,
 )
-from clinicadl.utils.exceptions import ClinicaDLConfigurationError
+from clinicadl.utils.exceptions import (
+    ClinicaDLArgumentError,
+    ClinicaDLConfigurationError,
+)
 
 from ...resources.objects import NETWORK, OPTIMIZER, TRAINING_STATE
 
-GOOD_PARAMETERS = [
-    ({}, "ConstantLR", ConstantLRConfig, ConstantLR),
-    ({"gamma": 1}, "ExponentialLR", ExponentialLRConfig, ExponentialLR),
-    ({}, "LinearLR", LinearLRConfig, LinearLR),
-    ({"step_size": 1}, "StepLR", StepLRConfig, StepLR),
-    ({"milestones": [1, 2]}, "MultiStepLR", MultiStepLRConfig, MultiStepLR),
-    ({}, "PolynomialLR", PolynomialLRConfig, PolynomialLR),
-    ({}, "ReduceLROnPlateau", ReduceLROnPlateauConfig, ReduceLROnPlateau),
-    ({"max_lr": 1, "total_steps": 10}, "OneCycleLR", OneCycleLRConfig, OneCycleLR),
-]
 
-
-@pytest.mark.parametrize(
-    "args,name,config,sched",
-    GOOD_PARAMETERS,
-)
-def test_scheduler_init(args, name, config, sched):
-    optimizer = OPTIMIZER.get_object(NETWORK.get_object())
-
-    with pytest.raises(
-        ValueError,
-        match="If you pass a LRScheduler via a name or a config class, you must also pass the associated optimizer via 'optimizer'.",
-    ):
-        LRScheduler(name, **args)
-    scheduler_from_str = LRScheduler(name, optimizer=optimizer, **args)
-    assert scheduler_from_str.config is not None
-    assert isinstance(scheduler_from_str.config, config)
-    assert isinstance(scheduler_from_str.scheduler, sched)
-
-    _config = config(**args)
-    with pytest.raises(
-        ValueError,
-        match="If you pass a LRScheduler via a name or a config class, you must also pass the associated optimizer via 'optimizer'.",
-    ):
-        LRScheduler(_config, **args)
-    scheduler_from_config = LRScheduler(_config, optimizer=optimizer)
-    assert scheduler_from_config.config is not None
-    assert scheduler_from_config.config == _config
-    assert isinstance(scheduler_from_str.scheduler, sched)
-
-
-def test_raw_scheduler():
+def test__init__():
+    # raw scheduler
     optimizer = OPTIMIZER.get_object(NETWORK.get_object())
     raw_scheduler = ConstantLR(optimizer)
     with pytest.raises(
@@ -86,24 +51,87 @@ def test_raw_scheduler():
     assert scheduler_from_raw.scheduler is raw_scheduler
     assert scheduler_from_raw.scheduler_type == "epoch-based"
 
+    # config
+    config = ConstantLRConfig()
+    scheduler_from_config = LRScheduler(config)
+    assert scheduler_from_config.config is config
+    assert scheduler_from_config.scheduler is None
+    assert scheduler_from_config.scheduler_type == "epoch-based"
+
+    # name
+    scheduler_from_name = LRScheduler("ConstantLR")
+    assert isinstance(scheduler_from_name.config, ConstantLRConfig)
+
 
 def test_on_train_begin():
+    # raw scheduler
     optimizer = OPTIMIZER.get_object(NETWORK.get_object())
-
-    scheduler = LRScheduler(LinearLRConfig(start_factor=0.5), optimizer=optimizer)
+    raw_scheduler = ConstantLR(optimizer)
+    scheduler = LRScheduler(
+        scheduler=raw_scheduler,
+        scheduler_type="epoch-based",
+        optimizer_key="optimizer_",
+    )
     with pytest.raises(
-        ClinicaDLConfigurationError,
+        ClinicaDLArgumentError,
         match=(
-            "The optimizer associated to the LR scheduler 'LinearLR' is not an optimizer returned by your ClinicaDLModel via the method 'get_optimizers'. "
-            "There is therefore a risk that this optimizer is not used during training."
+            re.escape(
+                "In LRScheduler, optimizer_key='optimizer_' but there is no such optimizer (returned by the 'get_optimizers' method of you ClinicaDLModel). "
+                "Optimizers are: ['optimizer']"
+            )
         ),
     ):
         scheduler.on_train_begin(TRAINING_STATE)
 
     scheduler = LRScheduler(
-        LinearLRConfig(start_factor=0.5), optimizer=TRAINING_STATE.model.optimizer
+        scheduler=raw_scheduler,
+        scheduler_type="epoch-based",
     )
+    with pytest.raises(
+        ClinicaDLConfigurationError,
+        match=(
+            re.escape(
+                "The optimizer associated to the LR scheduler 'ConstantLR' is not the same as "
+                "'optimizer' (returned by the 'get_optimizers' method of you ClinicaDLModel)."
+            )
+        ),
+    ):
+        scheduler.on_train_begin(TRAINING_STATE)
 
+    raw_scheduler = ConstantLR(TRAINING_STATE.model.optimizer)
+    scheduler = LRScheduler(scheduler=raw_scheduler, scheduler_type="epoch-based")
+
+    scheduler.on_train_begin(TRAINING_STATE)
+    optimizer.step()
+    scheduler.scheduler.step()
+    scheduler.scheduler.state_dict()["_last_lr"] = 0.0006
+    scheduler.on_train_begin(TRAINING_STATE)
+    scheduler.scheduler.state_dict()["_last_lr"] = 0.0005
+
+    # config
+    scheduler = LRScheduler(
+        scheduler=raw_scheduler,
+        scheduler_type="epoch-based",
+        optimizer_key="optimizer_",
+    )
+    with pytest.raises(
+        ClinicaDLArgumentError,
+        match=(
+            re.escape(
+                "In LRScheduler, optimizer_key='optimizer_' but there is no such optimizer (returned by the 'get_optimizers' method of you ClinicaDLModel). "
+                "Optimizers are: ['optimizer']"
+            )
+        ),
+    ):
+        scheduler.on_train_begin(TRAINING_STATE)
+
+    scheduler = LRScheduler(
+        scheduler=raw_scheduler,
+        scheduler_type="epoch-based",
+    )
+    scheduler.on_train_begin(TRAINING_STATE)
+    assert isinstance(scheduler.scheduler, ConstantLR)
+    assert scheduler.scheduler.optimizer is TRAINING_STATE.model.optimizer
     optimizer.step()
     scheduler.scheduler.step()
     scheduler.scheduler.state_dict()["_last_lr"] = 0.0006
@@ -115,11 +143,16 @@ def test_steps_scheduler():
     TRAINING_STATE.metrics._df = pd.DataFrame(
         {"epoch": [0], "mse": [1.0], "mae": [1.0], "loss": [0.5]}
     )
-    optimizer = OPTIMIZER.get_object(NETWORK.get_object())
-    sched = StepLR(optimizer, step_size=1)
-    epoch_scheduler = LRScheduler(StepLRConfig(step_size=1), optimizer=optimizer)
+    sched = StepLR(TRAINING_STATE.model.optimizer, step_size=1)
+    epoch_scheduler = LRScheduler(StepLRConfig(step_size=1))
     step_scheduler = LRScheduler(sched, scheduler_type="step-based")
-    metric_scheduler = LRScheduler(deepcopy(sched), scheduler_type="loss-based")
+    metric_scheduler = LRScheduler(
+        ReduceLROnPlateauConfig(), scheduler_type="loss-based"
+    )
+
+    epoch_scheduler.on_train_begin(TRAINING_STATE)
+    step_scheduler.on_train_begin(TRAINING_STATE)
+    metric_scheduler.on_train_begin(TRAINING_STATE)
 
     # Mock step to verify it's called
     epoch_scheduler.scheduler.step = MagicMock()

--- a/tests/unittests/metrics/test_config.py
+++ b/tests/unittests/metrics/test_config.py
@@ -1,23 +1,17 @@
-import logging
-
 import monai.metrics as metrics
 import pytest
-import torch
 import torchio as tio
 from monai.metrics import ConfusionMatrixMetric
 from pydantic import ValidationError
-from torch.nn import MSELoss
 
-from clinicadl.data.dataloader import Batch
-from clinicadl.data.structures import DataPoint
 from clinicadl.metrics.config import get_metric_config
-from clinicadl.metrics.config.base import LossMetricConfig
 from clinicadl.metrics.config.classification import (
     AveragePrecisionMetricConfig,
     ConfusionMatrixMetricConfig,
     ROCAUCMetricConfig,
 )
 from clinicadl.metrics.config.enum import ConfusionMatrixMetricName
+from clinicadl.metrics.config.loss import LossMetricConfig
 from clinicadl.metrics.config.reconstruction import (
     MultiScaleSSIMMetricConfig,
     PSNRMetricConfig,
@@ -313,45 +307,6 @@ def test_check_spatial_dim():
         MultiScaleSSIMMetricConfig(kernel_size=(2, 3), spatial_dims=3)
 
 
-def test_loss_metric(caplog):
-    config = LossMetricConfig(loss_fn=lambda x: x, reduction="mean")
-    assert config.reduction == "mean"
-    assert isinstance(config.get_object(), MonaiMetricWrapper)
-    assert isinstance(config.get_object().metric, metrics.LossMetric)
-
-    batch = Batch(
-        [
-            DataPoint(
-                image=tio.ScalarImage(tensor=torch.ones(1, 1, 1, 1)),
-                label=float(i),
-                output=float(i + 1),
-                participant=i,
-                session=i,
-            )
-            for i in range(3)
-        ]
-    )
-    config = LossMetricConfig(loss_fn=MSELoss(reduction="none"), reduction="mean")
-    assert config.loss_fn.reduction == "none"
-    assert config.reduction == "mean"
-    metric = config.get_object()
-    out = metric(batch)
-    assert out.shape == (3,)
-
-    config = LossMetricConfig(loss_fn=MSELoss(reduction="mean"), reduction="mean")
-    assert config.loss_fn.reduction == "none"
-    assert config.reduction == "mean"
-
-    with caplog.at_level(logging.WARNING):
-        config = LossMetricConfig(loss_fn=MSELoss(reduction="sum"), reduction="mean")
-    assert (
-        "The loss (MSELoss) has 'sum' reduction, "
-        "whereas in the metric associated to the loss you passed 'mean' reduction."
-    ) in caplog.text
-    assert config.loss_fn.reduction == "none"
-    assert config.reduction == "mean"
-
-
 MANDATORY_ARGS = {
     "max_val": 1,
     "class_thresholds": (0.5, 0.5),
@@ -425,6 +380,7 @@ def test_get_object(config, expected_class):
         ("MeanIoU", MeanIoUConfig),
         ("SurfaceDiceMetric", SurfaceDiceMetricConfig),
         ("SurfaceDistanceMetric", SurfaceDistanceMetricConfig),
+        ("LossMetric", LossMetricConfig),
     ],
 )
 def test_get_metric_config(name, config):
@@ -446,7 +402,6 @@ def test_get_metric_config(name, config):
 @pytest.mark.parametrize(
     "config,optimum",
     [
-        (LossMetricConfig, "min"),
         (ROCAUCMetricConfig, "max"),
         (AveragePrecisionMetricConfig, "max"),
         (MultiScaleSSIMMetricConfig, "max"),

--- a/tests/unittests/metrics/test_handler.py
+++ b/tests/unittests/metrics/test_handler.py
@@ -14,6 +14,11 @@ from clinicadl.data.structures import DataPoint
 from clinicadl.metrics import Metric
 from clinicadl.metrics.config import LossMetricConfig, MSEMetricConfig
 from clinicadl.metrics.handler import MetricsHandler
+from clinicadl.utils.exceptions import (
+    ClinicaDLArgumentError,
+    ClinicaDLConfigurationError,
+)
+from tests.unittests.resources.objects import MODEL
 
 DATAPOINTS = [
     DataPoint(
@@ -44,20 +49,22 @@ class CustomMetric(Metric):
 
 
 def test_MetricsHandler():
+    MODEL.loss = BCELoss()
     metrics = MetricsHandler(
-        loss=LossMetricConfig(
-            loss_fn=BCELoss(),
+        my_loss=LossMetricConfig(
+            loss_key="loss",
         ),
         mse=MSEMetricConfig(),
         my_metric=CustomMetric(),
     )
 
+    metrics.init_metrics(MODEL)
     metrics(BATCH_1)
     expected_df = pd.DataFrame.from_dict(
         {
+            "my_loss": pd.Series([0.0, 100.0, 0.0], dtype=np.float32),
             "mse": pd.Series([0.0, 1.0, 0.0], dtype=np.float32),
             "my_metric": pd.Series([1.0, 0.0, 1.0], dtype=np.float32),
-            "loss": pd.Series([0.0, 100.0, 0.0], dtype=np.float32),
             "participant_id": [f"sub-{i}" for i in range(3)],
             "session_id": [f"ses-{i}" for i in range(3)],
         }
@@ -67,9 +74,11 @@ def test_MetricsHandler():
     metrics(BATCH_2)
     expected_df = pd.DataFrame.from_dict(
         {
+            "my_loss": pd.Series(
+                [0.0, 100.0, 0.0, 100.0, 100.0, 0.0], dtype=np.float32
+            ),
             "mse": pd.Series([0.0, 1.0, 0.0, 1.0, 1.0, 0.0], dtype=np.float32),
             "my_metric": pd.Series([1.0, 0.0, 1.0, 0.0, 0.0, 1.0], dtype=np.float32),
-            "loss": pd.Series([0.0, 100.0, 0.0, 100.0, 100.0, 0.0], dtype=np.float32),
             "participant_id": [f"sub-{i}" for i in range(6)],
             "session_id": [f"ses-{i}" for i in range(6)],
         }
@@ -79,28 +88,57 @@ def test_MetricsHandler():
     metrics.aggregate()
     expected_df = pd.DataFrame.from_dict(
         {
+            "my_loss": pd.Series([50.0], dtype=np.float64),
             "mse": pd.Series([0.5], dtype=np.float64),
             "my_metric": pd.Series([0.5], dtype=np.float64),
-            "loss": pd.Series([50.0], dtype=np.float64),
         }
     )
     pd.testing.assert_frame_equal(metrics.df, expected_df)
 
 
-def test_reset():
+def test_init_metrics():
+    MODEL.loss = BCELoss()
     metrics = MetricsHandler(
         loss=LossMetricConfig(
-            loss_fn=BCELoss(),
+            loss_key="loss_",
         ),
         mse=MSEMetricConfig(),
     )
+
+    with pytest.raises(
+        ClinicaDLArgumentError,
+        match="In LossMetricConfig, loss_key='loss_' but there is no such loss*",
+    ):
+        metrics.init_metrics(MODEL)
+
+    metrics = MetricsHandler(
+        loss=LossMetricConfig(
+            loss_key="loss",
+        ),
+        mse=MSEMetricConfig(),
+    )
+
+    with pytest.raises(
+        ClinicaDLConfigurationError,
+        match="First, call 'init_metrics' to instantiate the metrics.",
+    ):
+        metrics(BATCH_1)
+
+    metrics.init_metrics(MODEL)
+    assert len(metrics._callable_metrics) == 2
+
+
+def test_reset():
+    metrics = MetricsHandler(
+        mse=MSEMetricConfig(),
+    )
+    metrics.init_metrics(MODEL)
 
     metrics(BATCH_1)
     metrics.aggregate()
     metrics.reset(reset_df=True)
     assert len(metrics.df) == 0
     assert len(metrics.detailed_df) == 0
-    metrics._callable_metrics["loss"].get_buffer() is None
     metrics._callable_metrics["mse"].get_buffer() is None
 
     metrics(BATCH_2)
@@ -108,7 +146,6 @@ def test_reset():
     metrics.reset()
     assert len(metrics.df) == 1
     assert len(metrics.detailed_df) == 3
-    metrics._callable_metrics["loss"].get_buffer() is None
     metrics._callable_metrics["mse"].get_buffer() is None
 
 
@@ -178,6 +215,8 @@ def test_epoch():
     metrics = MetricsHandler(
         mse=MSEMetricConfig(),
     )
+    metrics.init_metrics(MODEL)
+
     metrics(BATCH_1, epoch=0)
     metrics.aggregate(epoch=0)
     metrics.reset()
@@ -220,16 +259,22 @@ def test_add_metrics():
     metrics = MetricsHandler(
         mse=MSEMetricConfig(),
     )
+    metrics.init_metrics(MODEL)
     metrics(BATCH_1)
-    metrics.add_metrics(
-        loss=LossMetricConfig(loss_fn=BCELoss()), my_metric=CustomMetric()
-    )
+    metrics.aggregate()
+    metrics.add_metrics(my_metric=CustomMetric())
     metrics(BATCH_2)
+    metrics.aggregate()
     expected_df = pd.DataFrame.from_dict(
         {
-            "loss": pd.Series(
-                [np.nan, np.nan, np.nan, 100.0, 100.0, 0.0], dtype=np.float32
-            ),
+            "mse": pd.Series([0.33333, 0.66666], dtype=np.float64),
+            "my_metric": pd.Series([np.nan, 0.33333], dtype=np.float64),
+        }
+    )
+    pd.testing.assert_frame_equal(metrics.df, expected_df, rtol=1e-4)
+
+    expected_df = pd.DataFrame.from_dict(
+        {
             "mse": pd.Series([0.0, 1.0, 0.0, 1.0, 1.0, 0.0], dtype=np.float32),
             "my_metric": pd.Series(
                 [np.nan, np.nan, np.nan, 0.0, 0.0, 1.0], dtype=np.float32
@@ -244,31 +289,21 @@ def test_add_metrics():
 def test_get_metric():
     metrics = MetricsHandler(
         mse=MSEMetricConfig(),
-        loss=LossMetricConfig(
-            loss_fn=BCELoss(),
-        ),
     )
+    metrics.init_metrics(MODEL)
     metrics(BATCH_1)
     metrics.aggregate(epoch=0)
     metrics.reset()
     metrics(BATCH_2)
     metrics.aggregate(epoch=1)
     assert np.isclose(metrics.get_metric("mse"), 0.66666, rtol=1e-4)
-    assert np.isclose(metrics.get_loss(), 66.666, rtol=1e-4)
     assert np.isclose(metrics.get_metric("mse", epoch=0), 0.33333, rtol=1e-4)
-    assert np.isclose(metrics.get_loss(epoch=0), 33.333, rtol=1e-4)
 
 
 def test_checks():
     with pytest.raises(ValidationError):
         MetricsHandler(
             mse=lambda x: x,
-        )
-    with pytest.raises(
-        ValueError, match="Loss must be passed as a LossMetricConfig. Got function"
-    ):
-        MetricsHandler(
-            loss=lambda x: x,
         )
 
     config = MetricsHandler(
@@ -279,21 +314,13 @@ def test_checks():
     with pytest.raises(ValidationError):
         config.add_metrics(my_metric=lambda x: x)
 
-    with pytest.raises(
-        ValueError,
-        match="Loss must be passed as a LossMetricConfig. Got MSEMetricConfig",
-    ):
-        config.add_metrics(loss=MSEMetricConfig())
-    config.add_metrics(loss=LossMetricConfig(loss_fn=BCELoss()))
-    with pytest.raises(ValueError, match="You already passed a loss!"):
-        config.add_metrics(loss=LossMetricConfig(loss_fn=BCELoss()))
-
 
 def test_save_df(tmp_path):
     metrics = MetricsHandler(
-        loss=LossMetricConfig(loss_fn=BCELoss()),
         mse=MSEMetricConfig(),
     )
+    metrics.init_metrics(MODEL)
+
     metrics(BATCH_1)
     metrics.aggregate()
     metrics.save(tmp_path / "df.tsv")
@@ -301,7 +328,6 @@ def test_save_df(tmp_path):
     expected_df = pd.DataFrame.from_dict(
         {
             "mse": pd.Series([0.3333333]),
-            "loss": pd.Series([33.33333]),
         }
     )
     pd.testing.assert_frame_equal(df, expected_df)
@@ -311,7 +337,6 @@ def test_save_df(tmp_path):
     expected_df = pd.DataFrame.from_dict(
         {
             "mse": pd.Series([0.0, 1.0, 0.0]),
-            "loss": pd.Series([0.0, 100.0, 0.0]),
             "participant_id": [f"sub-{i}" for i in range(3)],
             "session_id": [f"ses-{i}" for i in range(3)],
         }
@@ -321,7 +346,6 @@ def test_save_df(tmp_path):
 
 def test_read_write_json(tmp_path):
     metrics = MetricsHandler(
-        loss=LossMetricConfig(loss_fn=BCELoss()),
         mse=MSEMetricConfig(),
     )
     metrics.add_metrics(my_metric=CustomMetric())
@@ -354,4 +378,16 @@ def test_read_write_json(tmp_path):
     )
     assert isinstance(metrics.metrics["mse"], MSEMetricConfig)
     assert isinstance(metrics.metrics["my_metric"], CustomMetric)
-    assert isinstance(metrics.metrics["loss"], LossMetricConfig)
+
+
+def test_empty():
+    metrics = MetricsHandler()
+    metrics.init_metrics(MODEL)
+    metrics(BATCH_1)
+    empty_df = pd.DataFrame.from_dict(
+        {
+            "participant_id": [f"sub-{i}" for i in range(3)],
+            "session_id": [f"ses-{i}" for i in range(3)],
+        }
+    )
+    pd.testing.assert_frame_equal(metrics.detailed_df, empty_df)

--- a/tests/unittests/metrics/test_handler.py
+++ b/tests/unittests/metrics/test_handler.py
@@ -52,7 +52,7 @@ def test_MetricsHandler():
     MODEL.loss = BCELoss()
     metrics = MetricsHandler(
         my_loss=LossMetricConfig(
-            loss_key="loss",
+            loss_name="loss",
         ),
         mse=MSEMetricConfig(),
         my_metric=CustomMetric(),
@@ -100,20 +100,20 @@ def test_init_metrics():
     MODEL.loss = BCELoss()
     metrics = MetricsHandler(
         loss=LossMetricConfig(
-            loss_key="loss_",
+            loss_name="loss_",
         ),
         mse=MSEMetricConfig(),
     )
 
     with pytest.raises(
         ClinicaDLArgumentError,
-        match="In LossMetricConfig, loss_key='loss_' but there is no such loss*",
+        match="In LossMetricConfig, loss_name='loss_' but there is no such loss*",
     ):
         metrics.init_metrics(MODEL)
 
     metrics = MetricsHandler(
         loss=LossMetricConfig(
-            loss_key="loss",
+            loss_name="loss",
         ),
         mse=MSEMetricConfig(),
     )

--- a/tests/unittests/metrics/test_handler.py
+++ b/tests/unittests/metrics/test_handler.py
@@ -157,6 +157,7 @@ def test_load(tmp_path):
         my_metric=CustomMetric(),
         mse=MSEMetricConfig(),
     )
+    metrics.init_metrics(MODEL)
     metrics.load(path=TSV_PATH / "validation.tsv")
     assert metrics._callable_metrics["loss"].get_buffer() is None
     excepted_df = pd.DataFrame.from_dict(

--- a/tests/unittests/metrics/test_loss.py
+++ b/tests/unittests/metrics/test_loss.py
@@ -15,12 +15,12 @@ from tests.unittests.resources.objects import MODEL
 
 
 def test_loss_metric():
-    config = LossMetricConfig(loss_key="loss_", reduction="mean")
+    config = LossMetricConfig(loss_name="loss_", reduction="mean")
     with pytest.raises(
         ClinicaDLArgumentError,
         match=(
             re.escape(
-                "In LossMetricConfig, loss_key='loss_' but there is no such loss (returned by the 'get_loss_functions' method of you ClinicaDLModel). "
+                "In LossMetricConfig, loss_name='loss_' but there is no such loss (returned by the 'get_loss_functions' method of you ClinicaDLModel). "
                 "Losses are: ['loss']"
             )
         ),
@@ -28,7 +28,7 @@ def test_loss_metric():
         config.get_object(MODEL)
 
     MODEL.loss = MSELoss(reduction="sum")
-    config = LossMetricConfig(loss_key="loss")
+    config = LossMetricConfig(loss_name="loss")
     assert isinstance(config.get_object(MODEL), MonaiMetricWrapper)
     assert isinstance(config.get_object(MODEL).metric, LossMetric)
     assert config.optimum() == "min"
@@ -52,7 +52,7 @@ def test_loss_metric():
     assert out.shape == (3,)
 
     MODEL.loss = lambda x: x
-    config = LossMetricConfig(loss_key="loss", reduction="mean", label_key=None)
+    config = LossMetricConfig(loss_name="loss", reduction="mean", label_key=None)
     with pytest.raises(
         ClinicaDLArgumentError,
         match=re.escape(

--- a/tests/unittests/metrics/test_loss.py
+++ b/tests/unittests/metrics/test_loss.py
@@ -1,0 +1,63 @@
+import re
+
+import pytest
+import torch
+import torchio as tio
+from monai.metrics import LossMetric
+from torch.nn import MSELoss
+
+from clinicadl.data.dataloader import Batch
+from clinicadl.data.structures import DataPoint
+from clinicadl.metrics.config import LossMetricConfig
+from clinicadl.metrics.monai_wrapper import MonaiMetricWrapper
+from clinicadl.utils.exceptions import ClinicaDLArgumentError
+from tests.unittests.resources.objects import MODEL
+
+
+def test_loss_metric():
+    config = LossMetricConfig(loss_key="loss_", reduction="mean")
+    with pytest.raises(
+        ClinicaDLArgumentError,
+        match=(
+            re.escape(
+                "In LossMetricConfig, loss_key='loss_' but there is no such loss (returned by the 'get_loss_functions' method of you ClinicaDLModel). "
+                "Losses are: ['loss']"
+            )
+        ),
+    ):
+        config.get_object(MODEL)
+
+    MODEL.loss = MSELoss(reduction="sum")
+    config = LossMetricConfig(loss_key="loss")
+    assert isinstance(config.get_object(MODEL), MonaiMetricWrapper)
+    assert isinstance(config.get_object(MODEL).metric, LossMetric)
+    assert config.optimum() == "min"
+    batch = Batch(
+        [
+            DataPoint(
+                image=tio.ScalarImage(tensor=torch.ones(1, 1, 1, 1)),
+                label=float(i),
+                output=float(i + 1),
+                participant=i,
+                session=i,
+            )
+            for i in range(3)
+        ]
+    )
+    metric: LossMetric = config.get_object(MODEL)
+    monai_metric = metric.metric
+    assert monai_metric.reduction == "sum"
+    assert monai_metric.loss_fn.reduction == "none"
+    out = metric(batch)
+    assert out.shape == (3,)
+
+    MODEL.loss = lambda x: x
+    config = LossMetricConfig(loss_key="loss", reduction="mean", label_key=None)
+    with pytest.raises(
+        ClinicaDLArgumentError,
+        match=re.escape(
+            "The loss 'loss' (returned by the 'get_loss_functions' method of you ClinicaDLModel) "
+            "doesn't have a 'reduction' attribute, so ClinicaDL can't compute the validation loss at the image level.",
+        ),
+    ):
+        config.get_object(MODEL)

--- a/tests/unittests/models/test_base.py
+++ b/tests/unittests/models/test_base.py
@@ -16,6 +16,9 @@ class CustomModel(ClinicaDLModel):
     def evaluation_step(self):
         pass
 
+    def get_loss_functions(self):
+        pass
+
     def get_optimizers(self):
         pass
 

--- a/tests/unittests/models/test_supervised.py
+++ b/tests/unittests/models/test_supervised.py
@@ -49,6 +49,9 @@ def test_SupervisedModel(tmp_path):
     assert isinstance(out_batch, Batch)
     assert out_batch[0]["output"].shape == (1,)
 
+    # get losses
+    assert model.get_loss_functions() == {"loss": model.loss}
+
     # get optimizers
     assert model.get_optimizers() == {"optimizer": model.optimizer}
 

--- a/tests/unittests/optim/lr_schedulers/config/test_factory.py
+++ b/tests/unittests/optim/lr_schedulers/config/test_factory.py
@@ -12,7 +12,7 @@ from clinicadl.optim.lr_schedulers.config import *
         ({"step_size": 1}, "StepLR", StepLRConfig, "epoch-based"),
         ({"milestones": [1, 2]}, "MultiStepLR", MultiStepLRConfig, "epoch-based"),
         ({}, "PolynomialLR", PolynomialLRConfig, "epoch-based"),
-        ({}, "ReduceLROnPlateau", ReduceLROnPlateauConfig, "loss-based"),
+        ({}, "ReduceLROnPlateau", ReduceLROnPlateauConfig, "metric-based"),
         (
             {"max_lr": 1, "total_steps": 10},
             "OneCycleLR",

--- a/tests/unittests/resources/objects.py
+++ b/tests/unittests/resources/objects.py
@@ -95,7 +95,7 @@ MODEL = SupervisedModel(
 )
 
 METRICS_HANDLER = MetricsHandler(
-    loss=LossMetricConfig(loss_fn=LOSS.get_object()),
+    loss=LossMetricConfig(),
     **{"mae": MAEMetricConfig(), "mse": MSEMetricConfig()},
 )
 


### PR DESCRIPTION
- tensors and neural networks can be send to the right device in the ``Trainer``.
- ``ClinicaDLModel`` has now a method named ``get_loss_functions`` that enables ``ClinicaDL`` to retrieve the loss functions to compute on the validation set.
- ``LossMetricConfig`` only accepts ``loss_name`` which is the name to the loss function in the output of the ``ClinicaDLModel.get_loss_functions``.
- ``MetricsHandler`` doesn't have a specific argument for losses. They must be passed like other metrics via config classes (``LossMetricConfig``). Thus, the user can change the ``pred_key`` and ``label_key``.
- ``LRScheduler`` has a ``metric_name`` (that refers to one of the metrics) for metric-based scheduler.