### PR TITLE
[CI] Add test coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,14 @@ jobs:
           cache: poetry
       - name: Run unit tests
         run: make unit-tests
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          flags: unittests
+          name: unittests-${{ matrix.os }}-py${{ matrix.python-version }}
+          fail_ci_if_error: false
 
   gpu-unit-tests:
     name: GPU unit tests
@@ -54,6 +62,14 @@ jobs:
           cache: poetry
       - name: Run unit tests
         run: make gpu-unit-tests
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          flags: gpu-unittests
+          name: gpu-unittests
+          fail_ci_if_error: false
 
   cpu-functional-test:
     name: Functional tests
@@ -72,6 +88,14 @@ jobs:
           cache: poetry
       - name: Run functional tests
         run: make functional-tests
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          flags: functional
+          name: functional
+          fail_ci_if_error: false
 
   gpu-functional-test:
     name: GPU functional tests
@@ -90,7 +114,15 @@ jobs:
           cache: poetry
       - name: Run functional tests
         run: make gpu-functional-tests
-  
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          flags: gpu-functional
+          name: gpu-functional
+          fail_ci_if_error: false
+
   multi-gpu-unit-tests:
     name: Multi-GPUs unit tests
     runs-on:
@@ -109,3 +141,11 @@ jobs:
         run: rm -rf ~/.cache/pypoetry ~/.cache/pip
       - name: Run unit tests
         run: make multi-gpu-unit-tests
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          flags: multi-gpu-unittests
+          name: multi-gpu-unittests
+          fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ clinicadl_debug.log
 
 # Code coverage and crash log files
 .coverage*
+coverage.xml
 crash*
 
 # Pytest files

--- a/Makefile
+++ b/Makefile
@@ -30,22 +30,24 @@ install.doc: check.lock ## Install only the docs dependency group
 	@$(POETRY) install --only docs
 
 ##@ Test
+COV ?= --cov=clinicadl --cov-report=xml --cov-report=term
+
 .PHONY: unit-tests
 unit-tests: install.dev ## Run unit tests (CPU only)
-	@$(POETRY) run python -m pytest -v -m "not gpu and not multi_gpu" tests/unittests
+	@$(POETRY) run python -m pytest -v $(COV) -m "not gpu and not multi_gpu" tests/unittests
 
 .PHONY: gpu-unit-tests
 gpu-unit-tests: install.dev ## Run unit tests on a single GPU
-	@$(POETRY) run python -m pytest -v -m "gpu" tests/unittests
+	@$(POETRY) run python -m pytest -v $(COV) -m "gpu" tests/unittests
 
 .PHONY: multi-gpu-unit-tests
 multi-gpu-unit-tests: install.dev ## Run unit tests on multiple GPUs
-	@$(POETRY) run python -m pytest -v -m "multi_gpu" tests/unittests
+	@$(POETRY) run python -m pytest -v $(COV) -m "multi_gpu" tests/unittests
 
 .PHONY: functional-tests
 functional-tests: install.dev ## Run functional tests (CPU only)
-	@$(POETRY) run python -m pytest -v -m "not gpu and not multi_gpu" --ref /localdrive10TB/users/clinicadl.ci/clinicadl_data_ci/data_ci tests/functional
+	@$(POETRY) run python -m pytest -v $(COV) -m "not gpu and not multi_gpu" --ref /localdrive10TB/users/clinicadl.ci/clinicadl_data_ci/data_ci tests/functional
 
 .PHONY: gpu-functional-tests
 gpu-functional-tests: install.dev ## Run functional tests on a single GPU
-	@$(POETRY) run python -m pytest -v -m "gpu" --ref /localdrive10TB/users/clinicadl.ci/clinicadl_data_ci/data_ci tests/functional
+	@$(POETRY) run python -m pytest -v $(COV) -m "gpu" --ref /localdrive10TB/users/clinicadl.ci/clinicadl_data_ci/data_ci tests/functional

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@
   <a href='https://github.com/aramis-lab/clinicadl/actions/workflows/test.yml'>
     <img src='https://github.com/aramis-lab/clinicadl/actions/workflows/test.yml/badge.svg' alt='CI tests status' />
   </a>
+  <a href='https://app.codecov.io/gh/aramis-lab/clinicadl'>
+    <img src='https://codecov.io/gh/aramislab/clinicadl/dev/graph/badge.svg' alt='CI tests status' />
+  </a>
   <a href='https://opensource.org/licenses/MIT'>
     <img src='https://img.shields.io/badge/License-MIT-yellow.svg' alt='License' />
   </a>

--- a/codecov.yml
+++ b/codecov.yml
@@ -15,7 +15,7 @@ coverage:
         informational: false  # fail the status check on a larger drop
     patch:
       default:
-        target: 90%           # new/changed lines must be 80% covered
+        target: 90%           # new/changed lines must be 90% covered
         threshold: 0%         # no tolerance, it is 90%
         informational: false
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,36 @@
+codecov:
+  notify:
+    # Wait for every coverage upload before finalizing the status.
+    # Each matrix cell counts as one upload:
+    #   cpu-unit (2 OS x 5 Python) = 10, gpu-unit = 1, multi-gpu = 1,
+    #   cpu-functional = 1, gpu-functional = 1  ->  14 total.
+    after_n_builds: 14
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto          # compare against the base commit
+        threshold: 1%         # allow a small drop without failing
+        informational: false  # fail the status check on a larger drop
+    patch:
+      default:
+        target: 90%           # new/changed lines must be 80% covered
+        threshold: 0%         # no tolerance, it is 90%
+        informational: false
+
+# Flags let Codecov merge the separate uploads from each test job and
+# carry the last known coverage forward when a job does not run on a PR.
+flag_management:
+  default_rules:
+    carryforward: true
+
+comment:
+  layout: "header, diff, flags, components"
+  require_changes: false
+
+# Files that should not count toward coverage.
+ignore:
+  - "tests/**"
+  - "docs/**"
+  - "examples/**"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,9 @@ Open-source Python library for reproducible deep learning in neuroimaging
     <a href='https://github.com/aramis-lab/clinicadl/actions/workflows/test.yml'>
         <img src='https://github.com/aramis-lab/clinicadl/actions/workflows/test.yml/badge.svg' alt='CI tests status' />
     </a>
+    <a href='https://app.codecov.io/gh/aramis-lab/clinicadl'>
+        <img src='https://codecov.io/gh/aramislab/clinicadl/dev/graph/badge.svg' alt='CI tests status' />
+    </a>
     <a href='https://opensource.org/licenses/MIT'>
         <img src='https://img.shields.io/badge/License-MIT-yellow.svg' alt='License' />
     </a>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,14 @@ line-ending = "auto"
 [tool.ruff.lint.per-file-ignores]
 "examples/*.py" = ["E402"]  # import not a the beginning
 
+[tool.coverage.run]
+source = ["clinicadl"]
+parallel = true
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+
 [tool.codespell]
 summary = ''
 skip = ".git,LICENSE.txt,*.m,clinicadl/resources/config/train_config.toml"


### PR DESCRIPTION
Implementation of [codecov](https://about.codecov.io/) in the CI.

CI tests now computes test coverage. The CI will fail if there is not enough coverage of the added lines or if the global coverage has dropped. The global coverage is aggregated from the coverages of all the CI tests.