### PR TITLE
Add MONAI loss configuration classes

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -37,6 +37,8 @@ authors:
     given-names: Ghislain
   - family-names: Wen
     given-names: Junhao
+  - family-names: Son
+    given-names: Colin
 title: " ClinicaDL: an open-source Python library for reproducible deep learning in neuroimaging."
 version: 2.0.0
 doi: 10.1016/j.cmpb.2022.106818

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -39,6 +39,8 @@ authors:
     given-names: Junhao
   - family-names: Son
     given-names: Colin
+    website: https://github.com/txmed82
+    orcid: https://orcid.org/0000-0002-1782-0537
 title: " ClinicaDL: an open-source Python library for reproducible deep learning in neuroimaging."
 version: 2.0.0
 doi: 10.1016/j.cmpb.2022.106818

--- a/clinicadl/losses/config/__init__.py
+++ b/clinicadl/losses/config/__init__.py
@@ -2,3 +2,4 @@
 
 from .configs import *
 from .enum import ImplementedLoss
+from .monai import *

--- a/clinicadl/losses/config/configs.py
+++ b/clinicadl/losses/config/configs.py
@@ -56,9 +56,9 @@ class LossConfig(ObjectConfig[torch.nn.Module]):
             The PyTorch loss function.
         """
         params = self.to_raw_dict()
-        if "weight" in params and params["weight"]:
+        if isinstance(params.get("weight"), list):
             params["weight"] = torch.Tensor(params["weight"])
-        if "pos_weight" in params and params["pos_weight"]:
+        if isinstance(params.get("pos_weight"), list):
             params["pos_weight"] = torch.Tensor(params["pos_weight"])
 
         associated_class = self._get_class()

--- a/clinicadl/losses/config/enum.py
+++ b/clinicadl/losses/config/enum.py
@@ -25,6 +25,8 @@ class ImplementedLoss(str, Enum):
     TVERSKY = "TverskyLoss"
     SOFT_CL_DICE = "SoftclDiceLoss"
 
+    SSIM = "SSIMLoss"
+
     @classmethod
     def _missing_(cls, value):
         raise ValueError(

--- a/clinicadl/losses/config/enum.py
+++ b/clinicadl/losses/config/enum.py
@@ -16,6 +16,14 @@ class ImplementedLoss(str, Enum):
     SMOOTH_L1 = "SmoothL1Loss"
     KLDIV = "KLDivLoss"
 
+    DICE = "DiceLoss"
+    DICE_CE = "DiceCELoss"
+    DICE_FOCAL = "DiceFocalLoss"
+    GENERALIZED_DICE = "GeneralizedDiceLoss"
+    GENERALIZED_DICE_FOCAL = "GeneralizedDiceFocalLoss"
+    FOCAL = "FocalLoss"
+    TVERSKY = "TverskyLoss"
+
     @classmethod
     def _missing_(cls, value):
         raise ValueError(
@@ -36,3 +44,11 @@ class Order(int, Enum):
 
     ONE = 1
     TWO = 2
+
+
+class GeneralizedDiceWeight(str, Enum):
+    """Supported class weighting modes for generalized Dice losses."""
+
+    SQUARE = "square"
+    SIMPLE = "simple"
+    UNIFORM = "uniform"

--- a/clinicadl/losses/config/enum.py
+++ b/clinicadl/losses/config/enum.py
@@ -23,6 +23,7 @@ class ImplementedLoss(str, Enum):
     GENERALIZED_DICE_FOCAL = "GeneralizedDiceFocalLoss"
     FOCAL = "FocalLoss"
     TVERSKY = "TverskyLoss"
+    SOFT_DICE = "SoftclDiceLoss"
 
     @classmethod
     def _missing_(cls, value):

--- a/clinicadl/losses/config/enum.py
+++ b/clinicadl/losses/config/enum.py
@@ -23,7 +23,7 @@ class ImplementedLoss(str, Enum):
     GENERALIZED_DICE_FOCAL = "GeneralizedDiceFocalLoss"
     FOCAL = "FocalLoss"
     TVERSKY = "TverskyLoss"
-    SOFT_DICE = "SoftclDiceLoss"
+    SOFT_CL_DICE = "SoftclDiceLoss"
 
     @classmethod
     def _missing_(cls, value):

--- a/clinicadl/losses/config/monai.py
+++ b/clinicadl/losses/config/monai.py
@@ -7,10 +7,14 @@ import torch
 from pydantic import (
     NonNegativeFloat,
     NonNegativeInt,
+    PositiveFloat,
+    PositiveInt,
     field_validator,
     model_validator,
 )
 
+from clinicadl.metrics.config.enum import Kernel
+from clinicadl.metrics.config.reconstruction import BaseSSIMConfig
 from clinicadl.utils.factories import get_defaults_from
 
 from .configs import LossConfig
@@ -26,6 +30,7 @@ __all__ = [
     "FocalLossConfig",
     "TverskyLossConfig",
     "SoftclDiceLossConfig",
+    "SSIMLossConfig",
 ]
 
 DICE_MONAI_DEFAULTS = get_defaults_from(monai.losses.DiceLoss)
@@ -38,6 +43,7 @@ GENERALIZED_DICE_FOCAL_MONAI_DEFAULTS = get_defaults_from(
 FOCAL_MONAI_DEFAULTS = get_defaults_from(monai.losses.FocalLoss)
 TVERSKY_MONAI_DEFAULTS = get_defaults_from(monai.losses.TverskyLoss)
 SOFT_CL_DICE_MONAI_DEFAULTS = get_defaults_from(monai.losses.SoftclDiceLoss)
+SSIM_MONAI_DEFAULTS = get_defaults_from(monai.losses.SSIMLoss)
 
 SerializableWeight = Optional[Union[NonNegativeFloat, list[NonNegativeFloat]]]
 
@@ -178,3 +184,20 @@ class SoftclDiceLossConfig(MonaiLossConfig):
 
     iter_: NonNegativeInt = SOFT_CL_DICE_MONAI_DEFAULTS["iter_"]
     smooth: float = SOFT_CL_DICE_MONAI_DEFAULTS["smooth"]
+
+
+class SSIMLossConfig(MonaiLossConfig, BaseSSIMConfig):
+    """Config class for :py:class:`monai.losses.ssim_loss.SSIMLoss`."""
+
+    spatial_dims: PositiveInt
+    data_range: PositiveFloat = SSIM_MONAI_DEFAULTS["data_range"]
+    kernel_type: Kernel = SSIM_MONAI_DEFAULTS["kernel_type"]
+    win_size: Union[PositiveInt, tuple[PositiveInt, ...]] = SSIM_MONAI_DEFAULTS[
+        "win_size"
+    ]
+    kernel_sigma: Union[PositiveFloat, tuple[PositiveFloat, ...]] = SSIM_MONAI_DEFAULTS[
+        "kernel_sigma"
+    ]
+    k1: NonNegativeFloat = SSIM_MONAI_DEFAULTS["k1"]
+    k2: NonNegativeFloat = SSIM_MONAI_DEFAULTS["k2"]
+    reduction: Reduction = SSIM_MONAI_DEFAULTS["reduction"]

--- a/clinicadl/losses/config/monai.py
+++ b/clinicadl/losses/config/monai.py
@@ -4,7 +4,12 @@ from typing import Callable, Optional, Union
 
 import monai.losses
 import torch
-from pydantic import NonNegativeFloat, field_validator, model_validator
+from pydantic import (
+    NonNegativeFloat,
+    NonNegativeInt,
+    field_validator,
+    model_validator,
+)
 
 from clinicadl.utils.factories import get_defaults_from
 
@@ -20,6 +25,7 @@ __all__ = [
     "GeneralizedDiceFocalLossConfig",
     "FocalLossConfig",
     "TverskyLossConfig",
+    "SoftclDiceLossConfig",
 ]
 
 DICE_MONAI_DEFAULTS = get_defaults_from(monai.losses.DiceLoss)
@@ -31,6 +37,7 @@ GENERALIZED_DICE_FOCAL_MONAI_DEFAULTS = get_defaults_from(
 )
 FOCAL_MONAI_DEFAULTS = get_defaults_from(monai.losses.FocalLoss)
 TVERSKY_MONAI_DEFAULTS = get_defaults_from(monai.losses.TverskyLoss)
+SOFT_CL_DICE_MONAI_DEFAULTS = get_defaults_from(monai.losses.SoftclDiceLoss)
 
 SerializableWeight = Optional[Union[NonNegativeFloat, list[NonNegativeFloat]]]
 
@@ -164,3 +171,10 @@ class TverskyLossConfig(_OverlapLossConfig):
     alpha: NonNegativeFloat = TVERSKY_MONAI_DEFAULTS["alpha"]
     beta: NonNegativeFloat = TVERSKY_MONAI_DEFAULTS["beta"]
     soft_label: bool = TVERSKY_MONAI_DEFAULTS["soft_label"]
+
+
+class SoftclDiceLossConfig(MonaiLossConfig):
+    """Config class for :py:class:`monai.losses.SoftclDiceLoss`."""
+
+    iter_: NonNegativeInt = SOFT_CL_DICE_MONAI_DEFAULTS["iter_"]
+    smooth: float = SOFT_CL_DICE_MONAI_DEFAULTS["smooth"]

--- a/clinicadl/losses/config/monai.py
+++ b/clinicadl/losses/config/monai.py
@@ -1,0 +1,166 @@
+"""Config classes for commonly used MONAI loss functions."""
+
+from typing import Callable, Optional, Union
+
+import monai.losses
+import torch
+from pydantic import NonNegativeFloat, field_validator, model_validator
+
+from clinicadl.utils.factories import get_defaults_from
+
+from .configs import LossConfig
+from .enum import GeneralizedDiceWeight, Reduction
+
+__all__ = [
+    "MonaiLossConfig",
+    "DiceLossConfig",
+    "DiceCELossConfig",
+    "DiceFocalLossConfig",
+    "GeneralizedDiceLossConfig",
+    "GeneralizedDiceFocalLossConfig",
+    "FocalLossConfig",
+    "TverskyLossConfig",
+]
+
+DICE_MONAI_DEFAULTS = get_defaults_from(monai.losses.DiceLoss)
+DICE_CE_MONAI_DEFAULTS = get_defaults_from(monai.losses.DiceCELoss)
+DICE_FOCAL_MONAI_DEFAULTS = get_defaults_from(monai.losses.DiceFocalLoss)
+GENERALIZED_DICE_MONAI_DEFAULTS = get_defaults_from(monai.losses.GeneralizedDiceLoss)
+GENERALIZED_DICE_FOCAL_MONAI_DEFAULTS = get_defaults_from(
+    monai.losses.GeneralizedDiceFocalLoss
+)
+FOCAL_MONAI_DEFAULTS = get_defaults_from(monai.losses.FocalLoss)
+TVERSKY_MONAI_DEFAULTS = get_defaults_from(monai.losses.TverskyLoss)
+
+SerializableWeight = Optional[Union[NonNegativeFloat, list[NonNegativeFloat]]]
+
+
+class MonaiLossConfig(LossConfig):
+    """Base config class for MONAI loss functions."""
+
+    @classmethod
+    def _get_class(cls) -> type[torch.nn.Module]:
+        """Returns the MONAI loss function associated to this config class."""
+        return getattr(monai.losses, cls._get_name())
+
+
+class _OverlapLossConfig(MonaiLossConfig):
+    """Parameters shared by overlap-based MONAI losses."""
+
+    include_background: bool = DICE_MONAI_DEFAULTS["include_background"]
+    to_onehot_y: bool = DICE_MONAI_DEFAULTS["to_onehot_y"]
+    sigmoid: bool = DICE_MONAI_DEFAULTS["sigmoid"]
+    softmax: bool = DICE_MONAI_DEFAULTS["softmax"]
+    other_act: Optional[Callable[[torch.Tensor], torch.Tensor]] = DICE_MONAI_DEFAULTS[
+        "other_act"
+    ]
+    reduction: Reduction = DICE_MONAI_DEFAULTS["reduction"]
+    smooth_nr: NonNegativeFloat = DICE_MONAI_DEFAULTS["smooth_nr"]
+    smooth_dr: NonNegativeFloat = DICE_MONAI_DEFAULTS["smooth_dr"]
+    batch: bool = DICE_MONAI_DEFAULTS["batch"]
+
+    @model_validator(mode="after")
+    def validate_activation(self):
+        """Only one activation may be enabled at a time."""
+        if sum((self.sigmoid, self.softmax, self.other_act is not None)) > 1:
+            raise ValueError(
+                "Only one of 'sigmoid', 'softmax' and 'other_act' may be set."
+            )
+        return self
+
+
+class _DiceLossConfig(_OverlapLossConfig):
+    """Parameters shared by Dice-based MONAI losses."""
+
+    squared_pred: bool = DICE_MONAI_DEFAULTS["squared_pred"]
+    jaccard: bool = DICE_MONAI_DEFAULTS["jaccard"]
+
+
+class DiceLossConfig(_DiceLossConfig):
+    """Config class for :py:class:`monai.losses.DiceLoss`."""
+
+    weight: SerializableWeight = DICE_MONAI_DEFAULTS["weight"]
+    soft_label: bool = DICE_MONAI_DEFAULTS["soft_label"]
+
+
+class DiceCELossConfig(_DiceLossConfig):
+    """Config class for :py:class:`monai.losses.DiceCELoss`."""
+
+    weight: Optional[list[NonNegativeFloat]] = DICE_CE_MONAI_DEFAULTS["weight"]
+    lambda_dice: NonNegativeFloat = DICE_CE_MONAI_DEFAULTS["lambda_dice"]
+    lambda_ce: NonNegativeFloat = DICE_CE_MONAI_DEFAULTS["lambda_ce"]
+    label_smoothing: NonNegativeFloat = DICE_CE_MONAI_DEFAULTS["label_smoothing"]
+
+    @field_validator("label_smoothing")
+    @classmethod
+    def validate_label_smoothing(cls, value):
+        if value > 1:
+            raise ValueError("'label_smoothing' must be between 0 and 1.")
+        return value
+
+
+class DiceFocalLossConfig(_DiceLossConfig):
+    """Config class for :py:class:`monai.losses.DiceFocalLoss`."""
+
+    gamma: NonNegativeFloat = DICE_FOCAL_MONAI_DEFAULTS["gamma"]
+    weight: SerializableWeight = DICE_FOCAL_MONAI_DEFAULTS["weight"]
+    lambda_dice: NonNegativeFloat = DICE_FOCAL_MONAI_DEFAULTS["lambda_dice"]
+    lambda_focal: NonNegativeFloat = DICE_FOCAL_MONAI_DEFAULTS["lambda_focal"]
+    alpha: Optional[NonNegativeFloat] = DICE_FOCAL_MONAI_DEFAULTS["alpha"]
+
+    @field_validator("alpha")
+    @classmethod
+    def validate_alpha(cls, value):
+        if value is not None and value > 1:
+            raise ValueError("'alpha' must be between 0 and 1.")
+        return value
+
+
+class _GeneralizedDiceLossConfig(_OverlapLossConfig):
+    """Parameters shared by generalized Dice MONAI losses."""
+
+    w_type: GeneralizedDiceWeight = GENERALIZED_DICE_MONAI_DEFAULTS["w_type"]
+
+
+class GeneralizedDiceLossConfig(_GeneralizedDiceLossConfig):
+    """Config class for :py:class:`monai.losses.GeneralizedDiceLoss`."""
+
+    soft_label: bool = GENERALIZED_DICE_MONAI_DEFAULTS["soft_label"]
+
+
+class GeneralizedDiceFocalLossConfig(_GeneralizedDiceLossConfig):
+    """Config class for :py:class:`monai.losses.GeneralizedDiceFocalLoss`."""
+
+    gamma: NonNegativeFloat = GENERALIZED_DICE_FOCAL_MONAI_DEFAULTS["gamma"]
+    weight: SerializableWeight = GENERALIZED_DICE_FOCAL_MONAI_DEFAULTS["weight"]
+    lambda_gdl: NonNegativeFloat = GENERALIZED_DICE_FOCAL_MONAI_DEFAULTS["lambda_gdl"]
+    lambda_focal: NonNegativeFloat = GENERALIZED_DICE_FOCAL_MONAI_DEFAULTS[
+        "lambda_focal"
+    ]
+
+
+class FocalLossConfig(MonaiLossConfig):
+    """Config class for :py:class:`monai.losses.FocalLoss`."""
+
+    include_background: bool = FOCAL_MONAI_DEFAULTS["include_background"]
+    to_onehot_y: bool = FOCAL_MONAI_DEFAULTS["to_onehot_y"]
+    gamma: NonNegativeFloat = FOCAL_MONAI_DEFAULTS["gamma"]
+    alpha: Optional[NonNegativeFloat] = FOCAL_MONAI_DEFAULTS["alpha"]
+    weight: SerializableWeight = FOCAL_MONAI_DEFAULTS["weight"]
+    reduction: Reduction = FOCAL_MONAI_DEFAULTS["reduction"]
+    use_softmax: bool = FOCAL_MONAI_DEFAULTS["use_softmax"]
+
+    @field_validator("alpha")
+    @classmethod
+    def validate_alpha(cls, value):
+        if value is not None and value > 1:
+            raise ValueError("'alpha' must be between 0 and 1.")
+        return value
+
+
+class TverskyLossConfig(_OverlapLossConfig):
+    """Config class for :py:class:`monai.losses.TverskyLoss`."""
+
+    alpha: NonNegativeFloat = TVERSKY_MONAI_DEFAULTS["alpha"]
+    beta: NonNegativeFloat = TVERSKY_MONAI_DEFAULTS["beta"]
+    soft_label: bool = TVERSKY_MONAI_DEFAULTS["soft_label"]

--- a/clinicadl/metrics/config/reconstruction.py
+++ b/clinicadl/metrics/config/reconstruction.py
@@ -11,6 +11,7 @@ from pydantic import (
 )
 
 from clinicadl.losses.config.enum import Reduction
+from clinicadl.utils.config import ClinicaDLConfig
 from clinicadl.utils.doc import add_suffix_to_doc
 from clinicadl.utils.factories import get_defaults_from
 
@@ -48,7 +49,7 @@ class PSNRMetricConfig(MetricConfig, _GetNotNansConfig):
         return Optimum.MAX
 
 
-class _BaseSSIMConfig(_GetNotNansConfig):
+class BaseSSIMConfig(ClinicaDLConfig):
     "Base config class for SSIM-related metrics."
 
     spatial_dims: PositiveInt
@@ -82,7 +83,7 @@ class _BaseSSIMConfig(_GetNotNansConfig):
 
 
 @add_suffix_to_doc(DOCUMENT_EXTRA_PARAMETERS)
-class SSIMMetricConfig(MetricConfig, _BaseSSIMConfig):
+class SSIMMetricConfig(MetricConfig, BaseSSIMConfig, _GetNotNansConfig):
     """
     Config class for :py:class:`monai.metrics.regression.SSIMMetric`.
 
@@ -116,7 +117,7 @@ class SSIMMetricConfig(MetricConfig, _BaseSSIMConfig):
 
 
 @add_suffix_to_doc(DOCUMENT_EXTRA_PARAMETERS)
-class MultiScaleSSIMMetricConfig(MetricConfig, _BaseSSIMConfig):
+class MultiScaleSSIMMetricConfig(MetricConfig, BaseSSIMConfig, _GetNotNansConfig):
     """
     Config class for :py:class:`monai.metrics.MultiScaleSSIMMetric`.
 

--- a/docs/api/losses.rst
+++ b/docs/api/losses.rst
@@ -58,3 +58,4 @@ MONAI Segmentation
    GeneralizedDiceFocalLossConfig
    FocalLossConfig
    TverskyLossConfig
+   SoftclDiceLossConfig

--- a/docs/api/losses.rst
+++ b/docs/api/losses.rst
@@ -59,3 +59,14 @@ MONAI Segmentation
    FocalLossConfig
    TverskyLossConfig
    SoftclDiceLossConfig
+
+
+MONAI Reconstruction
+^^^^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: ../generated/
+   :nosignatures:
+   :template: autosummary/config_object.rst
+
+   SSIMLossConfig

--- a/docs/api/losses.rst
+++ b/docs/api/losses.rst
@@ -41,3 +41,20 @@ Regression / Reconstruction
    SmoothL1LossConfig
    HuberLossConfig
    KLDivLossConfig
+
+
+MONAI Segmentation
+^^^^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: ../generated/
+   :nosignatures:
+   :template: autosummary/config_object.rst
+
+   DiceLossConfig
+   DiceCELossConfig
+   DiceFocalLossConfig
+   GeneralizedDiceLossConfig
+   GeneralizedDiceFocalLossConfig
+   FocalLossConfig
+   TverskyLossConfig

--- a/tests/unittests/losses/test_config.py
+++ b/tests/unittests/losses/test_config.py
@@ -22,6 +22,7 @@ from clinicadl.losses.config import (
     NLLLossConfig,
     SmoothL1LossConfig,
     SoftclDiceLossConfig,
+    SSIMLossConfig,
     TverskyLossConfig,
 )
 
@@ -179,28 +180,30 @@ def test_get_object(config, loss):
 def test_name():
     for name in ImplementedLoss:
         config = globals()[f"{name.value}Config"]
-        c = config()
+        c = config(spatial_dims=3)  # spatial_dims only for SSIMLossConfig
         assert c.name_ == name.value
 
 
 @pytest.mark.parametrize(
-    "config,loss",
+    "config,loss,mandatory_args",
     [
-        (DiceLossConfig, monai_losses.DiceLoss),
-        (DiceCELossConfig, monai_losses.DiceCELoss),
-        (DiceFocalLossConfig, monai_losses.DiceFocalLoss),
-        (GeneralizedDiceLossConfig, monai_losses.GeneralizedDiceLoss),
+        (DiceLossConfig, monai_losses.DiceLoss, {}),
+        (DiceCELossConfig, monai_losses.DiceCELoss, {}),
+        (DiceFocalLossConfig, monai_losses.DiceFocalLoss, {}),
+        (GeneralizedDiceLossConfig, monai_losses.GeneralizedDiceLoss, {}),
         (
             GeneralizedDiceFocalLossConfig,
             monai_losses.GeneralizedDiceFocalLoss,
+            {},
         ),
-        (FocalLossConfig, monai_losses.FocalLoss),
-        (TverskyLossConfig, monai_losses.TverskyLoss),
-        (SoftclDiceLossConfig, monai_losses.SoftclDiceLoss),
+        (FocalLossConfig, monai_losses.FocalLoss, {}),
+        (TverskyLossConfig, monai_losses.TverskyLoss, {}),
+        (SoftclDiceLossConfig, monai_losses.SoftclDiceLoss, {}),
+        (SSIMLossConfig, monai_losses.SSIMLoss, {"spatial_dims": 3}),
     ],
 )
-def test_get_monai_object(config, loss):
-    assert isinstance(config().get_object(), loss)
+def test_get_monai_object(config, loss, mandatory_args):
+    assert isinstance(config(**mandatory_args).get_object(), loss)
 
 
 @pytest.mark.parametrize(
@@ -230,6 +233,7 @@ def test_monai_loss_rejects_multiple_activations(config):
         (GeneralizedDiceLossConfig, {"w_type": "invalid"}),
         (TverskyLossConfig, {"smooth_dr": -1}),
         (SoftclDiceLossConfig, {"iter_": -1}),
+        (SSIMLossConfig, {"spatial_dims": 1}),
     ],
 )
 def test_bad_monai_inputs(config, kwargs):

--- a/tests/unittests/losses/test_config.py
+++ b/tests/unittests/losses/test_config.py
@@ -21,6 +21,7 @@ from clinicadl.losses.config import (
     MultiMarginLossConfig,
     NLLLossConfig,
     SmoothL1LossConfig,
+    SoftclDiceLossConfig,
     TverskyLossConfig,
 )
 
@@ -195,6 +196,7 @@ def test_name():
         ),
         (FocalLossConfig, monai_losses.FocalLoss),
         (TverskyLossConfig, monai_losses.TverskyLoss),
+        (SoftclDiceLossConfig, monai_losses.SoftclDiceLoss),
     ],
 )
 def test_get_monai_object(config, loss):
@@ -227,6 +229,7 @@ def test_monai_loss_rejects_multiple_activations(config):
         (GeneralizedDiceFocalLossConfig, {"lambda_gdl": -1}),
         (GeneralizedDiceLossConfig, {"w_type": "invalid"}),
         (TverskyLossConfig, {"smooth_dr": -1}),
+        (SoftclDiceLossConfig, {"iter_": -1}),
     ],
 )
 def test_bad_monai_inputs(config, kwargs):

--- a/tests/unittests/losses/test_config.py
+++ b/tests/unittests/losses/test_config.py
@@ -1,11 +1,18 @@
 import pytest
 import torch.nn as nn
+from monai import losses as monai_losses
 from pydantic import ValidationError
 
 from clinicadl.losses.config import (
     BCELossConfig,
     BCEWithLogitsLossConfig,
     CrossEntropyLossConfig,
+    DiceCELossConfig,
+    DiceFocalLossConfig,
+    DiceLossConfig,
+    FocalLossConfig,
+    GeneralizedDiceFocalLossConfig,
+    GeneralizedDiceLossConfig,
     HuberLossConfig,
     ImplementedLoss,
     KLDivLossConfig,
@@ -14,6 +21,7 @@ from clinicadl.losses.config import (
     MultiMarginLossConfig,
     NLLLossConfig,
     SmoothL1LossConfig,
+    TverskyLossConfig,
 )
 
 BAD_INPUTS = [
@@ -172,3 +180,61 @@ def test_name():
         config = globals()[f"{name.value}Config"]
         c = config()
         assert c.name_ == name.value
+
+
+@pytest.mark.parametrize(
+    "config,loss",
+    [
+        (DiceLossConfig, monai_losses.DiceLoss),
+        (DiceCELossConfig, monai_losses.DiceCELoss),
+        (DiceFocalLossConfig, monai_losses.DiceFocalLoss),
+        (GeneralizedDiceLossConfig, monai_losses.GeneralizedDiceLoss),
+        (
+            GeneralizedDiceFocalLossConfig,
+            monai_losses.GeneralizedDiceFocalLoss,
+        ),
+        (FocalLossConfig, monai_losses.FocalLoss),
+        (TverskyLossConfig, monai_losses.TverskyLoss),
+    ],
+)
+def test_get_monai_object(config, loss):
+    assert isinstance(config().get_object(), loss)
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        DiceLossConfig,
+        DiceCELossConfig,
+        DiceFocalLossConfig,
+        GeneralizedDiceLossConfig,
+        GeneralizedDiceFocalLossConfig,
+        TverskyLossConfig,
+    ],
+)
+def test_monai_loss_rejects_multiple_activations(config):
+    with pytest.raises(ValidationError, match="Only one"):
+        config(sigmoid=True, softmax=True)
+
+
+@pytest.mark.parametrize(
+    "config,kwargs",
+    [
+        (DiceCELossConfig, {"label_smoothing": 1.1}),
+        (DiceFocalLossConfig, {"alpha": 1.1}),
+        (FocalLossConfig, {"alpha": 1.1}),
+        (DiceFocalLossConfig, {"gamma": -1}),
+        (GeneralizedDiceFocalLossConfig, {"lambda_gdl": -1}),
+        (GeneralizedDiceLossConfig, {"w_type": "invalid"}),
+        (TverskyLossConfig, {"smooth_dr": -1}),
+    ],
+)
+def test_bad_monai_inputs(config, kwargs):
+    with pytest.raises(ValidationError):
+        config(**kwargs)
+
+
+def test_monai_weight_list_is_converted_to_tensor():
+    loss = FocalLossConfig(weight=[1, 2]).get_object()
+    assert loss.class_weight is not None
+    assert loss.class_weight.tolist() == [1, 2]

--- a/tests/unittests/losses/test_factory.py
+++ b/tests/unittests/losses/test_factory.py
@@ -6,30 +6,31 @@ from clinicadl.utils.json import read_json
 
 
 @pytest.mark.parametrize(
-    "config",
+    "config,mandatory_args",
     [
-        BCELossConfig,
-        BCEWithLogitsLossConfig,
-        CrossEntropyLossConfig,
-        HuberLossConfig,
-        KLDivLossConfig,
-        L1LossConfig,
-        MSELossConfig,
-        MultiMarginLossConfig,
-        NLLLossConfig,
-        SmoothL1LossConfig,
-        DiceLossConfig,
-        DiceCELossConfig,
-        DiceFocalLossConfig,
-        GeneralizedDiceLossConfig,
-        GeneralizedDiceFocalLossConfig,
-        FocalLossConfig,
-        TverskyLossConfig,
-        SoftclDiceLossConfig,
+        (BCELossConfig, {}),
+        (BCEWithLogitsLossConfig, {}),
+        (CrossEntropyLossConfig, {}),
+        (HuberLossConfig, {}),
+        (KLDivLossConfig, {}),
+        (L1LossConfig, {}),
+        (MSELossConfig, {}),
+        (MultiMarginLossConfig, {}),
+        (NLLLossConfig, {}),
+        (SmoothL1LossConfig, {}),
+        (DiceLossConfig, {}),
+        (DiceCELossConfig, {}),
+        (DiceFocalLossConfig, {}),
+        (GeneralizedDiceLossConfig, {}),
+        (GeneralizedDiceFocalLossConfig, {}),
+        (FocalLossConfig, {}),
+        (TverskyLossConfig, {}),
+        (SoftclDiceLossConfig, {}),
+        (SSIMLossConfig, {"spatial_dims": 3}),
     ],
 )
-def test_get_loss_function_from_dict(config, tmp_path):
-    c = config()
+def test_get_loss_function_from_dict(config, mandatory_args, tmp_path):
+    c = config(**mandatory_args)
     c.to_json(tmp_path / "config.json")
     dict_ = read_json(tmp_path / "config.json")
     c = get_loss_function_from_dict(dict_)

--- a/tests/unittests/losses/test_factory.py
+++ b/tests/unittests/losses/test_factory.py
@@ -25,6 +25,7 @@ from clinicadl.utils.json import read_json
         GeneralizedDiceFocalLossConfig,
         FocalLossConfig,
         TverskyLossConfig,
+        SoftclDiceLossConfig,
     ],
 )
 def test_get_loss_function_from_dict(config, tmp_path):

--- a/tests/unittests/losses/test_factory.py
+++ b/tests/unittests/losses/test_factory.py
@@ -18,6 +18,13 @@ from clinicadl.utils.json import read_json
         MultiMarginLossConfig,
         NLLLossConfig,
         SmoothL1LossConfig,
+        DiceLossConfig,
+        DiceCELossConfig,
+        DiceFocalLossConfig,
+        GeneralizedDiceLossConfig,
+        GeneralizedDiceFocalLossConfig,
+        FocalLossConfig,
+        TverskyLossConfig,
     ],
 )
 def test_get_loss_function_from_dict(config, tmp_path):
@@ -30,3 +37,15 @@ def test_get_loss_function_from_dict(config, tmp_path):
     if config is NLLLossConfig:
         c = NLLLossConfig(weight=[1, 2])
         assert get_loss_function_from_dict(c.to_dict()).weight == [1, 2]
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        DiceLossConfig(sigmoid=True, weight=[1, 2]),
+        GeneralizedDiceLossConfig(w_type="simple", soft_label=True),
+        FocalLossConfig(gamma=3, alpha=0.25, use_softmax=True),
+    ],
+)
+def test_monai_loss_non_default_round_trip(config):
+    assert get_loss_function_from_dict(config.to_dict()) == config


### PR DESCRIPTION
Closes #907

## Summary

- add typed, serializable configs for Dice, DiceCE, DiceFocal, generalized Dice, generalized Dice-Focal, Focal, and Tversky MONAI losses
- register the configs with the existing loss enum and factory while preserving MONAI 1.5.0 defaults
- validate activation exclusivity and bounded or non-negative parameters, with support for scalar and list class weights
- document the new public configuration classes

## Why

Raw MONAI losses already work in ClinicaDL, but their constructor parameters are not preserved in model configuration JSON. These config classes make common segmentation-loss choices reproducible and reloadable.

## Validation

- `pytest tests/unittests/losses -q` — 78 passed
- `pytest tests/unittests/models/test_factory.py tests/unittests/models/test_supervised.py tests/unittests/models/test_reconstruction.py tests/unittests/metrics/test_loss.py -q` — 5 passed
- affected pre-commit hooks — passed
- `make -C docs html` — succeeded with 7 pre-existing warnings
- a broader CPU unit run reached 959 passed, 1 skipped, and 12 deselected before being stopped during slow training tests; two environment-only failures caused by missing `pip` were rerun after installing it, and both passed
