### PR TITLE
[CI] Trigger functional tests when "ready for review"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: ["dev", "master"]
   pull_request:
     branches: ["dev", "master"]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
@@ -20,6 +21,7 @@ env:
 jobs:
   cpu-unit-tests:
     name: Unit tests on ${{ matrix.os }} with Python ${{ matrix.python-version }}
+    if: github.event.action != 'ready_for_review'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -48,6 +50,7 @@ jobs:
 
   gpu-unit-tests:
     name: GPU unit tests
+    if: github.event.action != 'ready_for_review'
     runs-on:
       - self-hosted
       - gpu
@@ -73,7 +76,12 @@ jobs:
 
   cpu-functional-test:
     name: Functional tests
-    if: github.event.pull_request.draft == false
+    if: >
+      github.event_name == 'push' ||
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.draft == false
+      )
     runs-on:
       - self-hosted
       - functional-tests
@@ -100,7 +108,12 @@ jobs:
 
   gpu-functional-test:
     name: GPU functional tests
-    if: github.event.pull_request.draft == false
+    if: >
+      github.event_name == 'push' ||
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.draft == false
+      )
     runs-on:
       - self-hosted
       - functional-tests
@@ -127,6 +140,7 @@ jobs:
 
   multi-gpu-unit-tests:
     name: Multi-GPUs unit tests
+    if: github.event.action != 'ready_for_review'
     runs-on:
       - self-hosted
       - multi-gpu


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://clinicadl.readthedocs.io/en/stable/contributing.html

ℹ️ This is a suggested pull request template for ClinicaDL.
If there is other information that would be helpful to include, please don't hesitate to add it!
-->

### Related issues
<!--
Example: Closes #1234. See also #3456.
Please use keywords (e.g., 'closes') to create links to the issues
you resolved, so that they will automatically be closed when your pull request
is merged. See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->
See also #925 #909 

### Key changes made
<!-- Brief bullet list of key changes -->
Previously, functional tests were not run when a PR was a draft, but nothing was happening during the conversion from "draft" to "ready for review". With this PR, functional tests will be triggered when the conversion occurs.

### Type of changes
<!-- Put an `x` in all the boxes that apply. -->
- [x] **Non-breaking** changes (fix or new feature that would not break existing functionality)
- [ ] **Breaking** changes (fix or new feature that would cause existing functionality to change)
- [ ] Changes involving **GPU** features
- [ ] Changes involving **multi-GPU** features
- [x] **No code-related** changes (e.g. documentation only)

### Checklist
<!--
Put an `x` in all the boxes that apply.
It is ok to open a PR even if you don't check all the boxes
(e.g. you don't have the necessary hardware to carry out GPU tests)!
-->
- [ ] In-line **docstrings** updated
- [ ] **Unit tests added** to cover the changes
- [ ] **Unit tests passed** locally (`make unit-tests`; and `make gpu-unit-tests`/`make multi-gpu-unit-tests`
      if the changes involve (multi-)GPU features)
- [ ] **Documentation** updated and tested (`cd docs && make html`) (if required)
- [ ] **CI database** updated (if required)

### AI usage disclosure
<!-- Put an `x` in all the boxes that apply. -->
I used AI assistance for:
- [ ] Code generation
- [ ] Test generation
- [ ] Documentation (including examples)
- [ ] Research and understanding

### Any other comments?
<!-- Thanks for contributing! 🚀 -->
