### PR TITLE
[DOC] Add '[only gpu]' flag to skip build conditions

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,7 +15,7 @@ build:
       - |
         COMMIT_MSG=$(git --no-pager log --pretty="format:%s %b" -1)
         echo "Commit message: $COMMIT_MSG"
-        if echo "$COMMIT_MSG" | grep -Eiq "\[skip ci\]|\[skip doc\]|\[only tests\]"; then
+        if echo "$COMMIT_MSG" | grep -Eiq "\[skip ci\]|\[skip doc\]|\[only tests\]|\[only gpu\]"; then
           echo "Skipping build due to commit flag."
           exit 183
         fi


### PR DESCRIPTION
<!--
🙌 Thanks for contributing a pull request!

👀 Please ensure you have taken a look at the contribution guidelines:
https://clinicadl.readthedocs.io/en/stable/contributing.html

ℹ️ This is a suggested pull request template for ClinicaDL.
If there is other information that would be helpful to include, please don't hesitate to add it!
-->

### Related issues
<!--
Example: Closes #1234. See also #3456.
Please use keywords (e.g., 'closes') to create links to the issues
you resolved, so that they will automatically be closed when your pull request
is merged. See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->
See also #909 and #932

### Key changes made
<!-- Brief bullet list of key changes -->
- Add the flag `[only gpu]` (introduced in #933) in the documentation configuration, so that the doc is not built when this flag is in the commit message. 

### Type of changes
<!-- Put an `x` in all the boxes that apply. -->
- [x] **Non-breaking** changes (fix or new feature that would not break existing functionality)
- [ ] **Breaking** changes (fix or new feature that would cause existing functionality to change)
- [ ] Changes involving **GPU** features
- [ ] Changes involving **multi-GPU** features
- [x] **No code-related** changes (e.g. documentation only)

### Checklist
<!--
Put an `x` in all the boxes that apply.
It is ok to open a PR even if you don't check all the boxes
(e.g. you don't have the necessary hardware to carry out GPU tests)!
-->
- [ ] In-line **docstrings** updated
- [ ] **Unit tests added** to cover the changes
- [ ] **Unit tests passed** locally (`make unit-tests`; and `make gpu-unit-tests`/`make multi-gpu-unit-tests`
      if the changes involve (multi-)GPU features)
- [ ] **Documentation** updated and tested (`cd docs && make html`) (if required)
- [ ] **CI database** updated (if required)

### AI usage disclosure
<!-- Put an `x` in all the boxes that apply. -->
I used AI assistance for:
- [ ] Code generation
- [ ] Test generation
- [ ] Documentation (including examples)
- [ ] Research and understanding

### Any other comments?
<!-- Thanks for contributing! 🚀 -->
