### PR TITLE
docs: update TorchIO documentation links

### DIFF
--- a/clinicadl/transforms/config/enum.py
+++ b/clinicadl/transforms/config/enum.py
@@ -6,7 +6,7 @@ from clinicadl.utils.enum import BaseEnum
 class ImplementedTransform(str, BaseEnum):
     """
     Implemented transforms in ClinicaDL.
-    see: https://torchio.readthedocs.io/transforms/transforms.html
+    see: https://docs.torchio.org/latest/transforms/
     """
 
     RESCALE_INTENSITY = "RescaleIntensity"
@@ -61,7 +61,7 @@ class ImplementedTransform(str, BaseEnum):
 class AnatomicalLabel(str, Enum):
     """
     Anatomical regions provided by TorchIO.
-    see: https://torchio.readthedocs.io/transforms/preprocessing.html#torchio.transforms.preprocessing.intensity.NormalizationTransform
+    see: https://docs.torchio.org/latest/transforms/preprocessing/#torchio.transforms.preprocessing.intensity.NormalizationTransform
     """
 
     LEFT = "Left"
@@ -75,7 +75,7 @@ class AnatomicalLabel(str, Enum):
 class InterpolationMode(str, BaseEnum):
     """
     Supported interpolation modes in TorchIO.
-    see: https://torchio.readthedocs.io/transforms/transforms.html#interpolation
+    see: https://docs.torchio.org/latest/transforms/#interpolation
     """
 
     NEAREST = "nearest"
@@ -94,7 +94,7 @@ class InterpolationMode(str, BaseEnum):
 class EnsureShapeMultipleMode(str, BaseEnum):
     """
     Supported modes for TorchIO's EnsureShapeMultiple.
-    see: https://torchio.readthedocs.io/transforms/preprocessing.html#torchio.transforms.EnsureShapeMultiple
+    see: https://docs.torchio.org/latest/transforms/preprocessing/EnsureShapeMultiple/
     """
 
     CROP = "crop"
@@ -104,7 +104,7 @@ class EnsureShapeMultipleMode(str, BaseEnum):
 class PaddingMode(str, BaseEnum):
     """
     Supported padding modes for TorchIO's Pad.
-    see: https://torchio.readthedocs.io/transforms/preprocessing.html#torchio.transforms.Pad
+    see: https://docs.torchio.org/latest/transforms/preprocessing/Pad/
     """
 
     EDGE = "edge"
@@ -121,7 +121,7 @@ class PaddingMode(str, BaseEnum):
 class CenterMode(str, BaseEnum):
     """
     Supported options for the parameter 'center' in TorchIO's RandomAffine.
-    see: https://torchio.readthedocs.io/transforms/augmentation.html#torchio.transforms.RandomAffine
+    see: https://docs.torchio.org/latest/transforms/augmentation/RandomAffine/
     """
 
     IMAGE = "image"
@@ -131,7 +131,7 @@ class CenterMode(str, BaseEnum):
 class RandomAffinePaddingMode(str, BaseEnum):
     """
     Supported options for the parameter 'default_pad_value' in TorchIO's RandomAffine.
-    see: https://torchio.readthedocs.io/transforms/augmentation.html#torchio.transforms.RandomAffine
+    see: https://docs.torchio.org/latest/transforms/augmentation/RandomAffine/
     """
 
     MINIMUM = "minimum"
@@ -142,7 +142,7 @@ class RandomAffinePaddingMode(str, BaseEnum):
 class AnatomicalAxis(str, BaseEnum):
     """
     Supported names for anatomical axes in TorchIO.
-    see: https://torchio.readthedocs.io/transforms/augmentation.html#torchio.transforms.RandomFlip
+    see: https://docs.torchio.org/latest/transforms/augmentation/RandomFlip/
     """
 
     LEFT_RIGHT = "LR"
@@ -163,7 +163,7 @@ class NumericalAxis(int, BaseEnum):
 class LockedBordersMode(int, BaseEnum):
     """
     Modes for 'locked_borders' argument in RandomElasticDeformation.
-    see: https://torchio.readthedocs.io/transforms/augmentation.html#torchio.transforms.RandomElasticDeformation
+    see: https://docs.torchio.org/latest/transforms/augmentation/RandomElasticDeformation/
     """
 
     ZERO = 0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,7 +57,7 @@ autodoc_member_order = "bysource"
 autodoc_typehints = "description"
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "torchio": ("https://torchio.readthedocs.io", None),
+    "torchio": ("https://docs.torchio.org/latest/", None),
     "monai": ("https://monai.readthedocs.io/en/stable/", None),
     "torch": ("https://pytorch.org/docs/stable", None),
     "pandas": ("https://pandas.pydata.org/docs", None),
@@ -87,7 +87,7 @@ extlinks = {
         "https://github.com/aramis-lab/clinicadl-zoo/tree/main/%s",
         None,
     ),
-    "torchio": ("https://torchio.readthedocs.io/%s", None),
+    "torchio": ("https://docs.torchio.org/latest/%s", None),
     "torch": ("https://pytorch.org/docs/stable/%s", None),
     "torchvision": ("https://docs.pytorch.org/vision/main/%s", None),
     "monai": ("https://monai.readthedocs.io/en/stable/%s", None),

--- a/docs/user_guide/data/transforms.rst
+++ b/docs/user_guide/data/transforms.rst
@@ -110,7 +110,7 @@ ClinicaDL works with **any callable that takes a**
 :py:class:`~clinicadl.data.structures.DataPoint` **and returns a** ``DataPoint``.
 This means you can use, as a transform:
 
-- any :torchio:`TorchIO transform <transforms/transforms.html>` — they operate on a
+- any :torchio:`TorchIO transform <transforms/>` — they operate on a
   :py:class:`torchio.Subject`, of which a ``DataPoint`` is a subclass;
 - any of your own functions following the same signature;
 - the two transforms ClinicaDL ships in :py:mod:`clinicadl.transforms`,


### PR DESCRIPTION
﻿## Summary
- Update the TorchIO intersphinx mapping to the current docs site at `docs.torchio.org/latest`.
- Update the `:torchio:` extlink base and the transform guide link to the current TorchIO paths.
- Refresh TorchIO reference URLs in transform enum docstrings.

Closes #917

## Validation
- Checked `https://docs.torchio.org/latest/objects.inv` returns 200.
- Checked updated explicit TorchIO documentation URLs return 200.
- Verified no `torchio.readthedocs.io` references remain under `docs`, `clinicadl`, or `README.md`.
